### PR TITLE
[REFACTOR]: forward embed instead of original message

### DIFF
--- a/src/events/messageCreate/watchForVRCWorldLinks/forwarding/index.ts
+++ b/src/events/messageCreate/watchForVRCWorldLinks/forwarding/index.ts
@@ -1,4 +1,9 @@
-import { EmbedBuilder, Message, messageLink } from 'discord.js';
+import {
+  EmbedBuilder,
+  Message,
+  messageLink,
+  OmitPartialGroupDMChannel
+} from 'discord.js';
 import { World } from 'vrchat';
 import logger from '../../../../utils/logger';
 import {
@@ -55,10 +60,7 @@ export const forwardToChannel = async (
 
     await markWorldAsProcessed(worldId);
 
-    const forwardedMessage = await message.forward(forwardingChannel.id);
-    if (forwardedMessage.channel.isSendable()) {
-      await forwardedMessage.channel.send({ embeds: [embed] });
-    }
+    await message.forward(forwardingChannel.id);
   } catch (error) {
     if (error.code === 40005) {
       logger.warn(
@@ -67,7 +69,7 @@ export const forwardToChannel = async (
 
       if (forwardingChannel.isSendable()) {
         await forwardingChannel.send({
-          content: `Original message omitted due to size  ${messageLink(message.channelId, message.id)}.`,
+          content: `Message omitted due to size — ${messageLink(message.channelId, message.id)}.`,
           embeds: [embed]
         });
       }
@@ -124,7 +126,7 @@ export const sendResponse = async (
   message: Message,
   embed: EmbedBuilder,
   worldId: string
-): Promise<void> => {
+): Promise<OmitPartialGroupDMChannel<Message<boolean>> | undefined> => {
   if (!message.channel.isSendable()) {
     return;
   }
@@ -133,7 +135,7 @@ export const sendResponse = async (
     await message.react(emojiMap.checkmark);
     await markWorldAsProcessed(worldId);
 
-    await message.reply({
+    return message.reply({
       allowedMentions: { repliedUser: false },
       embeds: [embed]
     });

--- a/src/events/messageCreate/watchForVRCWorldLinks/index.ts
+++ b/src/events/messageCreate/watchForVRCWorldLinks/index.ts
@@ -50,7 +50,7 @@ const extractMessageContent = (message: Message): string[] => {
 };
 
 /**
- * Processes a world ID: fetches data, creates embed, forwards, and sends response.
+ * Processes a world ID: fetches data, creates embed, sends the bot reply, then forwards it.
  */
 const processWorldId = async (
   message: Message,
@@ -84,17 +84,19 @@ const processWorldId = async (
     supportedPlatforms
   );
 
-  for (const channel of forwardingChannels) {
-    await forwardToChannel(
-      message,
-      channel.id,
-      channel.tag,
-      embed,
-      worldData.id
-    );
-  }
+  const responseMsg = await sendResponse(message, embed, worldData.id);
 
-  await sendResponse(message, embed, worldData.id);
+  if (responseMsg) {
+    for (const channel of forwardingChannels) {
+      await forwardToChannel(
+        responseMsg,
+        channel.id,
+        channel.tag,
+        embed,
+        worldData.id
+      );
+    }
+  }
 };
 
 export const forceRefetchWorldFromMessage = async (


### PR DESCRIPTION
## Description

Forwards the embed of the world link instead of the original message so all forwarded worlds can be traced to one single source of truth

## Type of change

- [x] New feature (non-breaking change that adds functionality)

## Checklist

- [x] Tests pass
- [x] No new warnings introduced
