### PR TITLE
[FEAT]: tetra_moon custom matcher, force refresh adds to tracked worlds

### DIFF
--- a/src/events/messageCreate/watchForVRCWorldLinks/index.ts
+++ b/src/events/messageCreate/watchForVRCWorldLinks/index.ts
@@ -2,6 +2,10 @@ import { Message } from 'discord.js';
 import logger from '../../../utils/logger';
 import { getSupportedPlatforms } from '../../../utils/helpers';
 import { has } from '../../../utils/jsonAsDb/handlers/persistentList';
+import {
+  getValue,
+  setValue
+} from '../../../utils/jsonAsDb/handlers/persistentKvp';
 import { kvKeys } from '../../../utils/jsonAsDb/types';
 import { extractWorldIdFromMessage } from './worldExtraction';
 import { fetchWorldData, calculatePackageSizes } from './worldData';
@@ -116,6 +120,25 @@ export const forceRefetchWorldFromMessage = async (
   }
 
   if (!worldId) return false;
+
+  const guildId = message.guildId;
+  if (guildId) {
+    const kvpKey = `${worldId}-${guildId}`;
+    const existingOriginal = await getValue(
+      kvKeys.PROCESSED_WORLDS_WITH_ORIGINAL_MESSAGE_ID,
+      kvpKey
+    );
+    if (!existingOriginal) {
+      await setValue(
+        kvKeys.PROCESSED_WORLDS_WITH_ORIGINAL_MESSAGE_ID,
+        kvpKey,
+        message.id
+      );
+      logger.info(
+        `Saving original message ID for world ${kvpKey} (force refetch): ${message.id}`
+      );
+    }
+  }
 
   await processWorldId(message, worldId, sourceContent, {
     skipDuplicateCheck: true

--- a/src/utils/regex/index.ts
+++ b/src/utils/regex/index.ts
@@ -39,6 +39,22 @@ export const customMatchers = {
       const afterBy = line.replace(/^By\s*[:：]?\s*/i, '').trim();
       return afterBy || null;
     }
+  },
+  tetra_moon: {
+    getWorldName: (content: string) => {
+      if (!content) return null;
+      const line = content.split('\n')[0]?.trim();
+      if (!line) return null;
+      const m = line.match(/^ワールド[\s\u3000]+(.+)$/);
+      return m?.[1]?.trim() ?? null;
+    },
+    getAuthorName: (content: string) => {
+      if (!content) return null;
+      const line = content.split('\n')[1]?.trim();
+      if (!line) return null;
+      const m = line.match(/^作者様[\s\u3000]+(.+)$/);
+      return m?.[1]?.trim() ?? null;
+    }
   }
 };
 

--- a/src/utils/regex/regex.test.ts
+++ b/src/utils/regex/regex.test.ts
@@ -183,6 +183,43 @@ describe('regex', () => {
         ).toBeNull();
       });
     });
+
+    describe('tetra_moon', () => {
+      const exampleTweet =
+        'ワールド　深海トンネルーUndersea Tunnel\n' +
+        '作者様　　そばこんぶ。\n' +
+        '\n' +
+        '海底トンネルのチルワールド\n' +
+        '外を泳ぐ色んな魚を眺めてゆっくりできる\n' +
+        'ちょっと薄暗いけどホラー要素は一切ないので、良い感じの写真を撮ろう\n' +
+        '#VRChat_world紹介 #VRChat';
+
+      it('getWorldName strips ワールド prefix (full-width spaces)', () => {
+        expect(customMatchers.tetra_moon.getWorldName(exampleTweet)).toBe(
+          '深海トンネルーUndersea Tunnel'
+        );
+      });
+
+      it('getAuthorName strips 作者様 prefix (full-width spaces)', () => {
+        expect(customMatchers.tetra_moon.getAuthorName(exampleTweet)).toBe(
+          'そばこんぶ。'
+        );
+      });
+
+      it('returns null for empty content', () => {
+        expect(customMatchers.tetra_moon.getWorldName('')).toBeNull();
+        expect(customMatchers.tetra_moon.getAuthorName('')).toBeNull();
+      });
+
+      it('returns null when lines do not match the label pattern', () => {
+        expect(
+          customMatchers.tetra_moon.getWorldName('Plain title\n作者様　x')
+        ).toBeNull();
+        expect(
+          customMatchers.tetra_moon.getAuthorName('ワールド　x\nPlain line')
+        ).toBeNull();
+      });
+    });
   });
 
   describe('extractWithCustomMatcher', () => {
@@ -217,6 +254,23 @@ describe('regex', () => {
       expect(result).toEqual({
         worldName: '星灯の丘 -Where the Night Learned to Shine-',
         authorName: '円花_madoka'
+      });
+    });
+
+    it('matches tetra_moon and returns world + author', () => {
+      const tetraTweet =
+        'ワールド　深海トンネルーUndersea Tunnel\n' +
+        '作者様　　そばこんぶ。\n' +
+        '\n' +
+        '海底トンネルのチルワールド\n' +
+        '#VRChat_world紹介 #VRChat';
+      const result = extractWithCustomMatcher(
+        'https://x.com/tetra_moon/status/123',
+        tetraTweet
+      );
+      expect(result).toEqual({
+        worldName: '深海トンネルーUndersea Tunnel',
+        authorName: 'そばこんぶ。'
       });
     });
 


### PR DESCRIPTION
## Description

Adds custom matcher for tetra_moon tweets, and makes force refresh add untracked worlds to tracked list.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would change existing behavior)
- [ ] Chore / maintenance (deps, config, tooling, etc.)

## Checklist

- [x] Tests pass
- [x] No new warnings introduced
