### PR TITLE
[FEAT]: handle refetch world info for webhook messages

### DIFF
--- a/.cursor/rules/message-processing-and-reactions.mdc
+++ b/.cursor/rules/message-processing-and-reactions.mdc
@@ -1,0 +1,16 @@
+---
+description: Keep Discord message and reaction handling consistent when changing filters or world-link behavior
+globs:
+  - src/bot.ts
+  - src/botFilters.ts
+  - src/events/messageCreate/**/*.ts
+  - src/events/messageReactionAdd/**/*.ts
+alwaysApply: false
+---
+
+When you change **message processing** (who may trigger handlers, what counts as an “original” post, webhook vs bot authors, watched channels, or world-link / duplicate behavior), also review **`src/events/messageReactionAdd/`** handlers. They act on **`reaction.message`** and often duplicate similar assumptions (e.g. author filtering, channel watch lists).
+
+- **Message entry:** `Events.MessageCreate` in `src/bot.ts` → `src/events/messageCreate/`.
+- **Reaction entry:** `Events.MessageReactionAdd` in `src/bot.ts` → `onReactionForward`, `onReactionToDelete`, `onReactionForceRefetch`, etc.
+
+If you introduce or adjust a rule like “ignore our bot but allow webhooks,” apply it in both paths where relevant. Reuse **`shouldIgnoreOwnBotMessage`** from `src/botFilters.ts` when the same self-vs-other logic is needed.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bot_vrc_world_tagger",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "packageManager": "pnpm@9.15.0",
   "main": "index.js",
   "scripts": {

--- a/src/bot.ts
+++ b/src/bot.ts
@@ -16,6 +16,9 @@ import logger from './utils/logger';
 import { isCurrentUser, vrchat } from './utils/externalApi/vrchat';
 import { shouldIgnoreOwnBotMessage } from './botFilters';
 
+// Message and reaction flows share policy (e.g. webhook vs self-bot). If you change
+// message handling filters or world-link behavior, review src/events/messageReactionAdd/
+// — see .cursor/rules/message-processing-and-reactions.mdc.
 const client = new Client({
   intents: [
     GatewayIntentBits.Guilds,

--- a/src/events/messageCreate/index.ts
+++ b/src/events/messageCreate/index.ts
@@ -1,3 +1,8 @@
+/**
+ * Incoming commands and world-link handling. If you change message filters or link
+ * processing, review reaction handlers under `src/events/messageReactionAdd/` for the
+ * same assumptions (see `.cursor/rules/message-processing-and-reactions.mdc`).
+ */
 import { Message } from 'discord.js';
 
 import watchForVRCWorldLinks from './watchForVRCWorldLinks';

--- a/src/events/messageReactionAdd/onReactionForceRefetch.test.ts
+++ b/src/events/messageReactionAdd/onReactionForceRefetch.test.ts
@@ -21,6 +21,8 @@ jest.mock('../../assets/media', () => ({
   }
 }));
 
+const OUR_BOT_ID = 'our-bot-id';
+
 const { has, add } = jest.requireMock(
   '../../utils/jsonAsDb/handlers/persistentList'
 ) as {
@@ -34,20 +36,31 @@ const { forceRefetchWorldFromMessage } = jest.requireMock(
   forceRefetchWorldFromMessage: jest.Mock;
 };
 
-const makeReaction = (overrides: Partial<any> = {}) =>
-  ({
-    emoji: { name: '♻', ...overrides.emoji },
+const makeReaction = (overrides: Partial<any> = {}) => {
+  const {
+    emoji: emojiOverride,
+    message: messageOverride,
+    client: clientOverride,
+    ...rest
+  } = overrides;
+
+  return {
+    emoji: { name: '♻', ...emojiOverride },
+    client: {
+      user: { id: OUR_BOT_ID, ...clientOverride?.user }
+    },
     message: {
       id: 'msg123',
       partial: false,
       fetch: jest.fn(),
       channelId: 'chan1',
-      author: { bot: false },
+      author: { id: 'human-1', bot: false },
       react: jest.fn(),
-      ...overrides.message
+      ...messageOverride
     },
-    ...overrides
-  }) as any;
+    ...rest
+  } as any;
+};
 
 describe('onReactionForceRefetch', () => {
   beforeEach(() => {
@@ -66,14 +79,34 @@ describe('onReactionForceRefetch', () => {
     expect(forceRefetchWorldFromMessage).not.toHaveBeenCalled();
   });
 
-  it('ignores bot-authored messages', async () => {
-    const reaction = makeReaction({ message: { author: { bot: true } } });
+  it('ignores messages authored by this bot', async () => {
+    const reaction = makeReaction({
+      message: { author: { id: OUR_BOT_ID, bot: true } }
+    });
     const user = { bot: false } as any;
 
     await onReactionForceRefetch(reaction, user);
 
     expect(has).not.toHaveBeenCalled();
     expect(forceRefetchWorldFromMessage).not.toHaveBeenCalled();
+  });
+
+  it('refetches when message author is another bot (e.g. webhook)', async () => {
+    has.mockImplementation((key: string) =>
+      Promise.resolve(key === 'WATCHED_CHANNELS')
+    );
+    add.mockResolvedValue({ success: true });
+    forceRefetchWorldFromMessage.mockResolvedValue(true);
+
+    const reaction = makeReaction({
+      message: { author: { id: 'other-bot-id', bot: true } }
+    });
+    const user = { bot: false } as any;
+
+    await onReactionForceRefetch(reaction, user);
+
+    expect(forceRefetchWorldFromMessage).toHaveBeenCalledWith(reaction.message);
+    expect(reaction.message.react).toHaveBeenCalledWith('✅');
   });
 
   it('only refetches in watched channels', async () => {

--- a/src/events/messageReactionAdd/onReactionForceRefetch.ts
+++ b/src/events/messageReactionAdd/onReactionForceRefetch.ts
@@ -3,6 +3,7 @@ import logger from '../../utils/logger';
 import { add, has } from '../../utils/jsonAsDb/handlers/persistentList';
 import { kvKeys } from '../../utils/jsonAsDb/types';
 import { emojiMap } from '../../assets/media';
+import { shouldIgnoreOwnBotMessage } from '../../botFilters';
 import { forceRefetchWorldFromMessage } from '../messageCreate/watchForVRCWorldLinks';
 
 export const onReactionForceRefetch = async (
@@ -24,8 +25,15 @@ export const onReactionForceRefetch = async (
     return;
   }
 
-  // Only refetch for original user messages, not bot replies/embeds.
-  if (message.author?.bot) return;
+  // Skip this bot's own replies; allow webhooks and other bots (original link posts).
+  if (
+    shouldIgnoreOwnBotMessage(
+      message.author.id,
+      reaction.client.user?.id
+    )
+  ) {
+    return;
+  }
 
   const isWatched = await has(kvKeys.WATCHED_CHANNELS, message.channelId);
   if (!isWatched) return;


### PR DESCRIPTION
## Description

Makes bot be able to refetch world info from webhook messages. Previous implementation would only handle reactions on human messages.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would change existing behavior)
- [ ] Chore / maintenance (deps, config, tooling, etc.)

## Checklist

- [x] Tests pass
- [x] No new warnings introduced
