### PR TITLE
[FEAT] [#59]: add undo feature

### DIFF
--- a/src/assets/media.ts
+++ b/src/assets/media.ts
@@ -5,7 +5,8 @@ export const emojiMap = {
   actually: '<:actually:1402298773517893684>',
   recycle: '♻',
   checkmark: '✅',
-  crossError: '❌'
+  crossError: '❌',
+  undo: '↩️'
 };
 
 export const images = {

--- a/src/bot.ts
+++ b/src/bot.ts
@@ -12,6 +12,7 @@ import messageCreate from './events/messageCreate';
 import { onReactionForward } from './events/messageReactionAdd/onReactionForward';
 import { onReactionToDelete } from './events/messageReactionAdd/onReactionToDelete';
 import { onReactionForceRefetch } from './events/messageReactionAdd/onReactionForceRefetch';
+import { onReactionUndoWorldTag } from './events/messageReactionAdd/onReactionUndoWorldTag';
 import logger from './utils/logger';
 import { isCurrentUser, vrchat } from './utils/externalApi/vrchat';
 import { shouldIgnoreOwnBotMessage } from './botFilters';
@@ -41,6 +42,7 @@ client.on(
       await onReactionForward(reaction, user);
       await onReactionToDelete(reaction, user);
       await onReactionForceRefetch(reaction, user);
+      await onReactionUndoWorldTag(reaction, user);
     } catch (error) {
       logger.error('Error in MessageReactionAdd handler:', error);
     }

--- a/src/events/messageCreate/watchForVRCWorldLinks/forwarding/index.ts
+++ b/src/events/messageCreate/watchForVRCWorldLinks/forwarding/index.ts
@@ -119,13 +119,19 @@ export const getForwardingChannels = async (
   return channels;
 };
 
+export type SendWorldResponseOptions = {
+  /** When true, react on the bot reply with the undo emoji (direct user content only). */
+  reactWithUndo?: boolean;
+};
+
 /**
  * Sends response to the original message
  */
 export const sendResponse = async (
   message: Message,
   embed: EmbedBuilder,
-  worldId: string
+  worldId: string,
+  options?: SendWorldResponseOptions
 ): Promise<OmitPartialGroupDMChannel<Message<boolean>> | undefined> => {
   if (!message.channel.isSendable()) {
     return;
@@ -135,10 +141,20 @@ export const sendResponse = async (
     await message.react(emojiMap.checkmark);
     await markWorldAsProcessed(worldId);
 
-    return message.reply({
+    const responseMsg = await message.reply({
       allowedMentions: { repliedUser: false },
       embeds: [embed]
     });
+
+    if (options?.reactWithUndo) {
+      try {
+        await responseMsg.react(emojiMap.undo);
+      } catch (err) {
+        logger.debug('Failed to react with undo on world reply:', err);
+      }
+    }
+
+    return responseMsg;
   } catch (error) {
     logger.error('Failed to send response to original message:', error);
   }

--- a/src/events/messageCreate/watchForVRCWorldLinks/index.ts
+++ b/src/events/messageCreate/watchForVRCWorldLinks/index.ts
@@ -19,38 +19,51 @@ import { checkAndHandleDuplicate } from './duplicateHandler';
 import Config from '../../../assets/config';
 
 /**
- * Extracts content from a message, handling both regular and forwarded messages
- * @param message - The Discord message to extract content from
- * @returns Array of content strings to check for VRChat world links
+ * Finds a world link in the message body first, then in forwarded snapshots.
+ * `fromDirectUserContent` is true only when the match came from `message.content`, not snapshots.
  */
-const extractMessageContent = (message: Message): string[] => {
-  const contentArray: string[] = [];
-
-  // Add the current message content
+const findFirstWorldMatch = async (
+  message: Message
+): Promise<{
+  worldId: string;
+  sourceContent: string;
+  fromDirectUserContent: boolean;
+} | null> => {
   if (message.content) {
-    contentArray.push(message.content);
     logger.debug(
-      `Added current message content: ${message.content.substring(0, 100)}...`
+      `Checking direct message content: ${message.content.substring(0, 100)}...`
     );
+    const fromBody = await extractWorldIdFromMessage(message.content);
+    if (fromBody) {
+      return {
+        worldId: fromBody,
+        sourceContent: message.content,
+        fromDirectUserContent: true
+      };
+    }
   }
 
-  // Add content from forwarded message snapshots
   if (message.messageSnapshots && message.messageSnapshots.size > 0) {
     logger.debug(
       `Found ${message.messageSnapshots.size} forwarded message snapshots`
     );
     for (const [, snapshot] of message.messageSnapshots) {
-      if (snapshot.content) {
-        contentArray.push(snapshot.content);
-        logger.debug(
-          `Added forwarded message content: ${snapshot.content.substring(0, 100)}...`
-        );
+      if (!snapshot.content) continue;
+      logger.debug(
+        `Checking forwarded snapshot content: ${snapshot.content.substring(0, 100)}...`
+      );
+      const fromSnapshot = await extractWorldIdFromMessage(snapshot.content);
+      if (fromSnapshot) {
+        return {
+          worldId: fromSnapshot,
+          sourceContent: snapshot.content,
+          fromDirectUserContent: false
+        };
       }
     }
   }
 
-  logger.debug(`Total content entries to check: ${contentArray.length}`);
-  return contentArray;
+  return null;
 };
 
 /**
@@ -60,9 +73,13 @@ const processWorldId = async (
   message: Message,
   worldId: string,
   sourceContent: string,
-  options?: { skipDuplicateCheck?: boolean }
+  options?: {
+    skipDuplicateCheck?: boolean;
+    reactWithUndoOnReply?: boolean;
+  }
 ): Promise<void> => {
   const skipDuplicateCheck = options?.skipDuplicateCheck ?? false;
+  const reactWithUndoOnReply = options?.reactWithUndoOnReply ?? false;
 
   if (!skipDuplicateCheck && !Config.DEV_MODE) {
     const isDuplicate = await checkAndHandleDuplicate(message, worldId);
@@ -88,7 +105,9 @@ const processWorldId = async (
     supportedPlatforms
   );
 
-  const responseMsg = await sendResponse(message, embed, worldData.id);
+  const responseMsg = await sendResponse(message, embed, worldData.id, {
+    reactWithUndo: reactWithUndoOnReply
+  });
 
   if (responseMsg) {
     for (const channel of forwardingChannels) {
@@ -106,20 +125,9 @@ const processWorldId = async (
 export const forceRefetchWorldFromMessage = async (
   message: Message
 ): Promise<boolean> => {
-  const contentArray = extractMessageContent(message);
-
-  let worldId: string | null = null;
-  let sourceContent = '';
-
-  for (const content of contentArray) {
-    worldId = await extractWorldIdFromMessage(content);
-    if (worldId) {
-      sourceContent = content;
-      break;
-    }
-  }
-
-  if (!worldId) return false;
+  const match = await findFirstWorldMatch(message);
+  if (!match) return false;
+  const { worldId, sourceContent, fromDirectUserContent } = match;
 
   const guildId = message.guildId;
   if (guildId) {
@@ -141,7 +149,8 @@ export const forceRefetchWorldFromMessage = async (
   }
 
   await processWorldId(message, worldId, sourceContent, {
-    skipDuplicateCheck: true
+    skipDuplicateCheck: true,
+    reactWithUndoOnReply: fromDirectUserContent
   });
   return true;
 };
@@ -161,32 +170,22 @@ const watchForVRCWorldLinks = async (message: Message): Promise<void> => {
   }
 
   try {
-    const contentArray = extractMessageContent(message);
-
-    let worldId: string | null = null;
-    let sourceContent = '';
-
-    for (const content of contentArray) {
-      worldId = await extractWorldIdFromMessage(content);
-      if (worldId) {
-        sourceContent = content;
-        break;
-      }
-    }
-
-    if (!worldId) {
+    const match = await findFirstWorldMatch(message);
+    if (!match) {
       return;
     }
 
+    const { worldId, sourceContent, fromDirectUserContent } = match;
+
     logger.info(
       `Processing VRC World link: ${worldId} from ${
-        message.messageSnapshots?.size > 0
-          ? 'forwarded message'
-          : 'direct message'
+        fromDirectUserContent ? 'direct message' : 'forwarded message'
       }`
     );
 
-    await processWorldId(message, worldId, sourceContent);
+    await processWorldId(message, worldId, sourceContent, {
+      reactWithUndoOnReply: fromDirectUserContent
+    });
   } catch (error) {
     logger.error('Error processing VRC world link:', error);
   }

--- a/src/events/messageReactionAdd/onReactionUndoWorldTag.test.ts
+++ b/src/events/messageReactionAdd/onReactionUndoWorldTag.test.ts
@@ -1,0 +1,148 @@
+import { onReactionUndoWorldTag } from './onReactionUndoWorldTag';
+import { emojiMap } from '../../assets/media';
+
+jest.mock('../messageCreate/watchForVRCWorldLinks/worldData', () => ({
+  fetchWorldData: jest.fn()
+}));
+
+jest.mock('../../utils/jsonAsDb/handlers/persistentList', () => ({
+  has: jest.fn(),
+  remove: jest.fn()
+}));
+
+jest.mock('../../utils/jsonAsDb/handlers/persistentKvp', () => ({
+  removeValue: jest.fn()
+}));
+
+const { has, remove } = jest.requireMock(
+  '../../utils/jsonAsDb/handlers/persistentList'
+) as { has: jest.Mock; remove: jest.Mock };
+const { removeValue } = jest.requireMock(
+  '../../utils/jsonAsDb/handlers/persistentKvp'
+) as { removeValue: jest.Mock };
+const { fetchWorldData } = jest.requireMock(
+  '../messageCreate/watchForVRCWorldLinks/worldData'
+) as { fetchWorldData: jest.Mock };
+
+const BOT_ID = 'bot-user-1';
+const WORLD_ID = 'wrld_aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee';
+const WORLD_URL = `https://vrchat.com/home/world/${WORLD_ID}`;
+
+const makeReaction = (overrides: Partial<any> = {}) => {
+  const { message: messageOverride, ...rest } = overrides;
+  const channelSend = jest.fn().mockResolvedValue(undefined);
+  return {
+    emoji: { name: emojiMap.undo, id: null, identifier: emojiMap.undo },
+    message: {
+      id: 'bot-reply-msg',
+      partial: false,
+      fetch: jest.fn(),
+      channelId: 'chan1',
+      guildId: 'guild1',
+      author: { id: BOT_ID, bot: true },
+      embeds: [{ url: WORLD_URL }],
+      content: '',
+      delete: jest.fn().mockResolvedValue(undefined),
+      channel: {
+        isSendable: () => true,
+        send: channelSend
+      },
+      ...messageOverride
+    },
+    client: { user: { id: BOT_ID } },
+    ...rest
+  } as any;
+};
+
+describe('onReactionUndoWorldTag', () => {
+  beforeEach(() => {
+    has.mockReset();
+    remove.mockReset();
+    removeValue.mockReset();
+    fetchWorldData.mockReset();
+    remove.mockResolvedValue({ success: true });
+    removeValue.mockResolvedValue(true);
+    fetchWorldData.mockResolvedValue({
+      name: 'Test World',
+      authorName: 'Author',
+      imageUrl: 'https://img.example/world.png'
+    });
+  });
+
+  it('ignores bot users', async () => {
+    const reaction = makeReaction();
+    await onReactionUndoWorldTag(reaction, { bot: true } as any);
+    expect(has).not.toHaveBeenCalled();
+    expect(reaction.message.delete).not.toHaveBeenCalled();
+  });
+
+  it('ignores non-undo emoji', async () => {
+    const reaction = makeReaction({
+      emoji: { name: '✅', id: null, identifier: '✅' }
+    });
+    await onReactionUndoWorldTag(reaction, { bot: false } as any);
+    expect(has).not.toHaveBeenCalled();
+  });
+
+  it('ignores when channel is not watched for reacts', async () => {
+    has.mockResolvedValue(false);
+    const reaction = makeReaction();
+    await onReactionUndoWorldTag(reaction, { bot: false } as any);
+    expect(reaction.message.delete).not.toHaveBeenCalled();
+    expect(remove).not.toHaveBeenCalled();
+  });
+
+  it('ignores non-bot message authors', async () => {
+    has.mockResolvedValue(true);
+    const reaction = makeReaction({
+      message: { author: { id: 'human', bot: false } }
+    });
+    await onReactionUndoWorldTag(reaction, { bot: false } as any);
+    expect(reaction.message.delete).not.toHaveBeenCalled();
+    expect(remove).not.toHaveBeenCalled();
+  });
+
+  it('does nothing when no world id can be resolved', async () => {
+    has.mockResolvedValue(true);
+    const reaction = makeReaction({
+      message: { embeds: [], content: 'no world here' }
+    });
+    await onReactionUndoWorldTag(reaction, { bot: false } as any);
+    expect(remove).not.toHaveBeenCalled();
+    expect(reaction.message.delete).not.toHaveBeenCalled();
+  });
+
+  it('removes db entries and deletes bot message', async () => {
+    has.mockImplementation((key: string) =>
+      Promise.resolve(key === 'WATCHED_REACTION_CHANNELS')
+    );
+    const reaction = makeReaction();
+    await onReactionUndoWorldTag(reaction, { bot: false } as any);
+
+    expect(remove).toHaveBeenCalledWith(
+      'PROCESSED_WORLDS',
+      WORLD_ID
+    );
+    expect(removeValue).toHaveBeenCalledWith(
+      'PROCESSED_WORLDS_WITH_ORIGINAL_MESSAGE_ID',
+      `${WORLD_ID}-guild1`
+    );
+    expect(remove).toHaveBeenCalledWith(
+      'REACTION_FORWARDED_MESSAGE_IDS',
+      'bot-reply-msg'
+    );
+    expect(reaction.message.delete).toHaveBeenCalled();
+    expect(fetchWorldData).toHaveBeenCalledWith(WORLD_ID);
+    expect(reaction.message.channel.send).toHaveBeenCalledWith({
+      embeds: expect.arrayContaining([
+        expect.objectContaining({
+          data: expect.objectContaining({
+            color: 0xed4245,
+            title: 'Test World by Author',
+            url: WORLD_URL
+          })
+        })
+      ])
+    });
+  });
+});

--- a/src/events/messageReactionAdd/onReactionUndoWorldTag.ts
+++ b/src/events/messageReactionAdd/onReactionUndoWorldTag.ts
@@ -1,0 +1,118 @@
+import { EmbedBuilder, Message, MessageReaction, User } from 'discord.js';
+import { emojiMap } from '../../assets/media';
+import logger from '../../utils/logger';
+import { buildWorldUrl } from '../../utils/helpers';
+import { extractWorldId } from '../../utils/regex';
+import { has, remove } from '../../utils/jsonAsDb/handlers/persistentList';
+import { removeValue } from '../../utils/jsonAsDb/handlers/persistentKvp';
+import { kvKeys } from '../../utils/jsonAsDb/types';
+import { getEmojiKey } from '../../utils/discord/reactionEmoji';
+import { fetchWorldData } from '../messageCreate/watchForVRCWorldLinks/worldData';
+
+/** Discord-style red for destructive / removal feedback */
+const UNDO_CONFIRM_EMBED_COLOR = 0xed4245;
+
+function reactionIsUndo(reaction: MessageReaction): boolean {
+  return getEmojiKey(reaction) === emojiMap.undo;
+}
+
+function getWorldIdFromBotWorldMessage(message: Message): string | null {
+  const embed = message.embeds[0];
+  if (embed?.url) {
+    const fromUrl = extractWorldId(embed.url);
+    if (fromUrl) return fromUrl;
+  }
+  if (message.content) {
+    return extractWorldId(message.content);
+  }
+  return null;
+}
+
+export const onReactionUndoWorldTag = async (
+  reaction: MessageReaction,
+  user: User
+): Promise<void> => {
+  if (user.bot) return;
+
+  if (!reactionIsUndo(reaction)) return;
+
+  try {
+    if (reaction.message.partial) {
+      await reaction.message.fetch();
+    }
+  } catch (error) {
+    logger.error('Failed to fetch partial message for undo world tag:', error);
+    return;
+  }
+
+  const message = reaction.message as Message;
+  const channelId = message.channelId;
+
+  const isWatchedForReacts = await has(
+    kvKeys.WATCHED_REACTION_CHANNELS,
+    channelId
+  );
+  if (!isWatchedForReacts) return;
+
+  if (message.author?.id !== reaction.client.user?.id) return;
+
+  const guildId = message.guildId;
+  if (!guildId) return;
+
+  const worldId = getWorldIdFromBotWorldMessage(message);
+  if (!worldId) {
+    logger.debug(
+      `Undo reaction on bot message ${message.id}: no world id in embed/content, skipping`
+    );
+    return;
+  }
+
+  let worldData: Awaited<ReturnType<typeof fetchWorldData>> | null = null;
+  try {
+    worldData = await fetchWorldData(worldId);
+  } catch (error) {
+    logger.warn(
+      `Could not fetch world ${worldId} for undo confirmation embed:`,
+      error
+    );
+  }
+
+  const kvpKey = `${worldId}-${guildId}`;
+  const channel = message.channel;
+
+  await remove(kvKeys.PROCESSED_WORLDS, worldId);
+  await removeValue(kvKeys.PROCESSED_WORLDS_WITH_ORIGINAL_MESSAGE_ID, kvpKey);
+  await remove(kvKeys.REACTION_FORWARDED_MESSAGE_IDS, message.id);
+
+  try {
+    await message.delete();
+  } catch (error) {
+    logger.error(
+      `Failed to delete bot message ${message.id} after undo world tag:`,
+      error
+    );
+  }
+
+  if (channel.isSendable()) {
+    const embed = new EmbedBuilder()
+      .setColor(UNDO_CONFIRM_EMBED_COLOR)
+      .setTitle(
+        worldData
+          ? `${worldData.name} by ${worldData.authorName}`
+          : 'World removed from bot database'
+      )
+      .setURL(buildWorldUrl(worldId))
+      .setDescription(
+        'This world was removed from the bot database. The world info message was deleted.'
+      )
+      .setTimestamp();
+    if (worldData?.imageUrl) {
+      embed.setThumbnail(worldData.imageUrl);
+    }
+    try {
+      await channel.send({ embeds: [embed] });
+    } catch (error) {
+      logger.error('Failed to send undo confirmation embed:', error);
+    }
+  }
+};


### PR DESCRIPTION
## Issue
Closes #59 

## Description

Adds an undo feature to the bot, which will allow users to easily delete worlds added/tagged by mistake.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would change existing behavior)
- [ ] Chore / maintenance (deps, config, tooling, etc.)

## Checklist

- [x] Tests pass
- [ ] No new warnings introduced
