### PR TITLE
feat(regex): strip (iOS対応) from fox_yata9 world names

### DIFF
--- a/src/utils/regex/index.ts
+++ b/src/utils/regex/index.ts
@@ -92,6 +92,7 @@ export const customMatchers = {
           const name = m[1]
             .trim()
             .replace(/\s*\(QUEST対応\)/g, '')
+            .replace(/\s*\(iOS対応\)/g, '')
             .trim();
           return name || null;
         }

--- a/src/utils/regex/regex.test.ts
+++ b/src/utils/regex/regex.test.ts
@@ -309,6 +309,21 @@ describe('regex', () => {
         );
       });
 
+      it('getWorldName strips (iOS対応)', () => {
+        const tweet = 'World:Some World Name(iOS対応)\n' + 'By:AuthorName\n';
+        expect(customMatchers.fox_yata9.getWorldName(tweet)).toBe(
+          'Some World Name'
+        );
+      });
+
+      it('getWorldName strips (QUEST対応) and (iOS対応) when both present', () => {
+        const tweet =
+          'World:Hybrid World(QUEST対応)(iOS対応)\n' + 'By:AuthorName\n';
+        expect(customMatchers.fox_yata9.getWorldName(tweet)).toBe(
+          'Hybrid World'
+        );
+      });
+
       it('getAuthorName strips By: prefix', () => {
         expect(customMatchers.fox_yata9.getAuthorName(exampleTweet)).toBe(
           'PlayerBush001'


### PR DESCRIPTION
## Summary

Extends the `fox_yata9` custom matcher `getWorldName` to strip `(iOS対応)` from extracted world titles, matching the existing behavior for `(QUEST対応)`.

## Changes

- Chain a `.replace(/\s*\(iOS対応\)/g, '')` after the QUEST suffix removal in `src/utils/regex/index.ts`.
- Add Jest coverage for iOS-only titles and for worlds that include both QUEST and iOS suffixes.

## Notes

- Default branch on this repo is `main` (there is no `master` branch).

Work was done in a separate git worktree at `bot_vrc_world_tagger-worktrees/fox-yata9-ios`.

Made with [Cursor](https://cursor.com)