### PR TITLE
[FEAT] [#66]: world id from file name

### DIFF
--- a/src/events/messageCreate/watchForVRCWorldLinks/forceRefetch.test.ts
+++ b/src/events/messageCreate/watchForVRCWorldLinks/forceRefetch.test.ts
@@ -1,9 +1,13 @@
-import { Message } from 'discord.js';
+import { Attachment, Message } from 'discord.js';
 import { kvKeys } from '../../../utils/jsonAsDb/types';
 
 jest.mock('../../../utils/jsonAsDb/handlers/persistentKvp', () => ({
   getValue: jest.fn(),
   setValue: jest.fn()
+}));
+
+jest.mock('../../../utils/jsonAsDb/handlers/persistentList', () => ({
+  has: jest.fn()
 }));
 
 jest.mock('./worldExtraction', () => ({
@@ -56,6 +60,7 @@ import {
   getValue,
   setValue
 } from '../../../utils/jsonAsDb/handlers/persistentKvp';
+import { has } from '../../../utils/jsonAsDb/handlers/persistentList';
 import { extractWorldIdFromMessage } from './worldExtraction';
 import { fetchWorldData, calculatePackageSizes } from './worldData';
 import { forceRefetchWorldFromMessage } from './index';
@@ -76,6 +81,7 @@ describe('forceRefetchWorldFromMessage', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    (has as jest.Mock).mockResolvedValue(true);
     (extractWorldIdFromMessage as jest.Mock).mockResolvedValue(WRLD);
     (fetchWorldData as jest.Mock).mockResolvedValue({
       id: WRLD,
@@ -131,5 +137,48 @@ describe('forceRefetchWorldFromMessage', () => {
 
     expect(result).toBe(false);
     expect(getValue).not.toHaveBeenCalled();
+  });
+
+  it('returns false when channel is not watched (including attachment filenames)', async () => {
+    (has as jest.Mock).mockResolvedValue(false);
+    (extractWorldIdFromMessage as jest.Mock).mockResolvedValue(null);
+
+    const att = { name: `capture-${WRLD}.png` } as Attachment;
+    const message = {
+      ...makeMessage(),
+      content: '',
+      attachments: {
+        values: () => [att].values() as IterableIterator<Attachment>
+      }
+    } as unknown as Message;
+
+    const result = await forceRefetchWorldFromMessage(message);
+
+    expect(result).toBe(false);
+    expect(has).toHaveBeenCalledWith(kvKeys.WATCHED_CHANNELS, 'chan-1');
+    expect(getValue).not.toHaveBeenCalled();
+  });
+
+  it('refetches world id from attachment filename when message text has none', async () => {
+    (extractWorldIdFromMessage as jest.Mock).mockResolvedValue(null);
+    (getValue as jest.Mock).mockResolvedValue(undefined);
+    (setValue as jest.Mock).mockResolvedValue(true);
+
+    const att = { name: `capture-${WRLD}.png` } as Attachment;
+    const message = {
+      ...makeMessage(),
+      content: '',
+      attachments: {
+        values: () => [att].values() as IterableIterator<Attachment>
+      }
+    } as unknown as Message;
+
+    const result = await forceRefetchWorldFromMessage(message);
+
+    expect(result).toBe(true);
+    expect(getValue).toHaveBeenCalledWith(
+      kvKeys.PROCESSED_WORLDS_WITH_ORIGINAL_MESSAGE_ID,
+      `${WRLD}-guild-1`
+    );
   });
 });

--- a/src/events/messageCreate/watchForVRCWorldLinks/index.ts
+++ b/src/events/messageCreate/watchForVRCWorldLinks/index.ts
@@ -1,6 +1,7 @@
 import { Message } from 'discord.js';
 import logger from '../../../utils/logger';
 import { getSupportedPlatforms } from '../../../utils/helpers';
+import { extractAllWorldIds } from '../../../utils/regex';
 import { has } from '../../../utils/jsonAsDb/handlers/persistentList';
 import {
   getValue,
@@ -18,17 +19,52 @@ import {
 import { checkAndHandleDuplicate } from './duplicateHandler';
 import Config from '../../../assets/config';
 
-/**
- * Finds a world link in the message body first, then in forwarded snapshots.
- * `fromDirectUserContent` is true only when the match came from `message.content`, not snapshots.
- */
-const findFirstWorldMatch = async (
-  message: Message
-): Promise<{
+type WorldMatchSource = 'body' | 'snapshot' | 'attachment';
+
+type WorldMatch = {
   worldId: string;
   sourceContent: string;
-  fromDirectUserContent: boolean;
-} | null> => {
+  sourceKind: WorldMatchSource;
+};
+
+const eachAttachment = (message: Message) =>
+  message.attachments?.values() ?? [][Symbol.iterator]();
+
+const attachmentWorldIdsInOrder = (message: Message): string[] => {
+  const ordered: string[] = [];
+  const seen = new Set<string>();
+  for (const attachment of eachAttachment(message)) {
+    for (const id of extractAllWorldIds(attachment.name ?? '')) {
+      if (!seen.has(id)) {
+        seen.add(id);
+        ordered.push(id);
+      }
+    }
+  }
+  return ordered;
+};
+
+const attachmentDisplayNameForWorldId = (
+  message: Message,
+  worldId: string
+): string => {
+  for (const attachment of eachAttachment(message)) {
+    if (extractAllWorldIds(attachment.name ?? '').includes(worldId)) {
+      return attachment.name ?? worldId;
+    }
+  }
+  return worldId;
+};
+
+/**
+ * Finds a world link in the message body first, then in forwarded snapshots.
+ * When `scanAttachmentFilenames` is true, attachment file names are checked last
+ * (only use in watched channels — see `watchForVRCWorldLinks` / `forceRefetchWorldFromMessage`).
+ */
+const findFirstWorldMatch = async (
+  message: Message,
+  scanAttachmentFilenames: boolean
+): Promise<WorldMatch | null> => {
   if (message.content) {
     logger.debug(
       `Checking direct message content: ${message.content.substring(0, 100)}...`
@@ -38,7 +74,7 @@ const findFirstWorldMatch = async (
       return {
         worldId: fromBody,
         sourceContent: message.content,
-        fromDirectUserContent: true
+        sourceKind: 'body'
       };
     }
   }
@@ -57,13 +93,56 @@ const findFirstWorldMatch = async (
         return {
           worldId: fromSnapshot,
           sourceContent: snapshot.content,
-          fromDirectUserContent: false
+          sourceKind: 'snapshot'
+        };
+      }
+    }
+  }
+
+  if (scanAttachmentFilenames) {
+    for (const attachment of eachAttachment(message)) {
+      const ids = extractAllWorldIds(attachment.name ?? '');
+      if (ids.length > 0) {
+        return {
+          worldId: ids[0],
+          sourceContent: attachment.name ?? ids[0],
+          sourceKind: 'attachment'
         };
       }
     }
   }
 
   return null;
+};
+
+const buildWorldProcessQueue = async (
+  message: Message,
+  scanAttachmentFilenames: boolean
+): Promise<WorldMatch[]> => {
+  const primary = await findFirstWorldMatch(message, scanAttachmentFilenames);
+  const fromFilenames = scanAttachmentFilenames
+    ? attachmentWorldIdsInOrder(message)
+    : [];
+  const seen = new Set<string>();
+  const queue: WorldMatch[] = [];
+
+  if (primary) {
+    queue.push(primary);
+    seen.add(primary.worldId);
+  }
+
+  for (const worldId of fromFilenames) {
+    if (!seen.has(worldId)) {
+      seen.add(worldId);
+      queue.push({
+        worldId,
+        sourceContent: attachmentDisplayNameForWorldId(message, worldId),
+        sourceKind: 'attachment'
+      });
+    }
+  }
+
+  return queue;
 };
 
 /**
@@ -118,10 +197,26 @@ const processWorldId = async (
   }
 };
 
+const sourceKindLogLabel = (kind: WorldMatchSource): string => {
+  switch (kind) {
+    case 'body':
+      return 'direct message';
+    case 'snapshot':
+      return 'forwarded message';
+    case 'attachment':
+      return 'attachment filename';
+  }
+};
+
 export const forceRefetchWorldFromMessage = async (
   message: Message
 ): Promise<boolean> => {
-  const match = await findFirstWorldMatch(message);
+  const isWatched = await has(kvKeys.WATCHED_CHANNELS, message.channelId);
+  if (!isWatched) {
+    return false;
+  }
+
+  const match = await findFirstWorldMatch(message, true);
   if (!match) return false;
   const { worldId, sourceContent } = match;
 
@@ -165,20 +260,17 @@ const watchForVRCWorldLinks = async (message: Message): Promise<void> => {
   }
 
   try {
-    const match = await findFirstWorldMatch(message);
-    if (!match) {
+    const queue = await buildWorldProcessQueue(message, true);
+    if (queue.length === 0) {
       return;
     }
 
-    const { worldId, sourceContent, fromDirectUserContent } = match;
-
-    logger.info(
-      `Processing VRC World link: ${worldId} from ${
-        fromDirectUserContent ? 'direct message' : 'forwarded message'
-      }`
-    );
-
-    await processWorldId(message, worldId, sourceContent);
+    for (const match of queue) {
+      logger.info(
+        `Processing VRC World link: ${match.worldId} from ${sourceKindLogLabel(match.sourceKind)}`
+      );
+      await processWorldId(message, match.worldId, match.sourceContent);
+    }
   } catch (error) {
     logger.error('Error processing VRC world link:', error);
   }

--- a/src/utils/regex/index.ts
+++ b/src/utils/regex/index.ts
@@ -119,6 +119,25 @@ export function extractWorldId(message: string): string | null {
   return match?.[0] ?? null;
 }
 
+/**
+ * Returns every unique VRChat world id found in `text`, in order of first appearance.
+ */
+export function extractAllWorldIds(text: string): string[] {
+  if (!text) return [];
+  const re = new RegExp(VRCHAT_WORLD_ID_REGEX.source, 'g');
+  const matches = text.match(re);
+  if (!matches?.length) return [];
+  const seen = new Set<string>();
+  const ordered: string[] = [];
+  for (const id of matches) {
+    if (!seen.has(id)) {
+      seen.add(id);
+      ordered.push(id);
+    }
+  }
+  return ordered;
+}
+
 export function getLinkFromMessage(message: string): string | null {
   if (!message) return null;
   const match = message.match(GENERIC_LINK_REGEX);

--- a/src/utils/regex/regex.test.ts
+++ b/src/utils/regex/regex.test.ts
@@ -4,7 +4,8 @@ import {
   extractWorldAndAuthorByLines,
   extractWorldAndAuthor,
   customMatchers,
-  extractWithCustomMatcher
+  extractWithCustomMatcher,
+  extractAllWorldIds
 } from './index';
 
 // Mock the config to avoid environment variable dependencies
@@ -604,6 +605,27 @@ describe('regex', () => {
       const noWorldData = `Just some random text\n#VRChat`;
       const result = extractWorldAndAuthor(noWorldData);
       expect(result).toBeNull();
+    });
+  });
+
+  describe('extractAllWorldIds', () => {
+    const id1 = 'wrld_aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee';
+    const id2 = 'wrld_bbbbbbbb-bbbb-cccc-dddd-eeeeeeeeeeee';
+
+    it('returns empty for empty or non-matching text', () => {
+      expect(extractAllWorldIds('')).toEqual([]);
+      expect(extractAllWorldIds('no id here')).toEqual([]);
+    });
+
+    it('returns unique ids in first-appearance order', () => {
+      expect(extractAllWorldIds(`${id2} foo ${id1} bar ${id2}`)).toEqual([
+        id2,
+        id1
+      ]);
+    });
+
+    it('finds an id embedded in a filename', () => {
+      expect(extractAllWorldIds(`screenshot-${id1}.png`)).toEqual([id1]);
     });
   });
 });


### PR DESCRIPTION
## Issue
Closes #66 

## Description

- Add extractAllWorldIds for ordered unique wrld_ matches in text
- Process queue: body/snapshot match first, then additional IDs from filenames
- Gate attachment filename scanning behind watched channel (explicit flag + force refetch guard)
- Tests for extractAllWorldIds, attachment refetch, and unwatched refetch

Made-with: Cursor

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would change existing behavior)
- [ ] Chore / maintenance (deps, config, tooling, etc.)

## Checklist

- [x] Tests pass
- [ ] No new warnings introduced
