### PR TITLE
[FEAT] [#54]: ignored users list

### DIFF
--- a/src/bot.ts
+++ b/src/bot.ts
@@ -16,6 +16,7 @@ import { onReactionUndoWorldTag } from './events/messageReactionAdd/onReactionUn
 import logger from './utils/logger';
 import { isCurrentUser, vrchat } from './utils/externalApi/vrchat';
 import { shouldIgnoreOwnBotMessage } from './botFilters';
+import { isUserOnIgnoreList } from './utils/ignoreList';
 
 // Message and reaction flows share policy (e.g. webhook vs self-bot). If you change
 // message handling filters or world-link behavior, review src/events/messageReactionAdd/
@@ -39,6 +40,8 @@ client.on(
   Events.MessageReactionAdd,
   async (reaction: MessageReaction, user: User) => {
     try {
+      if (user.bot) return;
+      if (await isUserOnIgnoreList(user.id)) return;
       await onReactionForward(reaction, user);
       await onReactionToDelete(reaction, user);
       await onReactionForceRefetch(reaction, user);

--- a/src/events/messageCreate/ignoreMe.test.ts
+++ b/src/events/messageCreate/ignoreMe.test.ts
@@ -1,0 +1,56 @@
+import { ignoreMe } from './ignoreMe';
+import { add, has } from '../../utils/jsonAsDb/handlers/persistentList';
+
+jest.mock('../../utils/jsonAsDb/handlers/persistentList', () => ({
+  add: jest.fn(),
+  has: jest.fn()
+}));
+
+const mockedHas = has as jest.MockedFunction<typeof has>;
+const mockedAdd = add as jest.MockedFunction<typeof add>;
+
+const makeMessage = (authorId: string) => {
+  const send = jest.fn().mockResolvedValue(undefined);
+  return {
+    author: { id: authorId, bot: false },
+    channel: { isSendable: () => true, send }
+  } as any;
+};
+
+describe('ignoreMe', () => {
+  beforeEach(() => {
+    mockedHas.mockReset();
+    mockedAdd.mockReset();
+  });
+
+  it('tells the user when already ignored', async () => {
+    mockedHas.mockResolvedValue(true);
+    const message = makeMessage('u1');
+    await ignoreMe(message);
+    expect(mockedAdd).not.toHaveBeenCalled();
+    expect(message.channel.send).toHaveBeenCalledWith(
+      'You are already on the ignore list.'
+    );
+  });
+
+  it('adds the user and confirms', async () => {
+    mockedHas.mockResolvedValue(false);
+    mockedAdd.mockResolvedValue({ success: true });
+    const message = makeMessage('u2');
+    await ignoreMe(message);
+    expect(mockedAdd).toHaveBeenCalled();
+    expect(message.channel.send).toHaveBeenCalledWith(
+      expect.stringContaining('You are now on the ignore list')
+    );
+  });
+
+  it('reports failure when add does not succeed', async () => {
+    mockedHas.mockResolvedValue(false);
+    mockedAdd.mockResolvedValue({ success: false, error: 'disk full' });
+    const message = makeMessage('u3');
+    await ignoreMe(message);
+    expect(message.channel.send).toHaveBeenCalledWith(
+      'Could not update the ignore list. Please try again later.'
+    );
+  });
+});

--- a/src/events/messageCreate/ignoreMe.ts
+++ b/src/events/messageCreate/ignoreMe.ts
@@ -1,0 +1,33 @@
+import { Message } from 'discord.js';
+import { add, has } from '../../utils/jsonAsDb/handlers/persistentList';
+import { kvKeys } from '../../utils/jsonAsDb/types';
+import logger from '../../utils/logger';
+
+export const ignoreMe = async (message: Message): Promise<void> => {
+  const authorId = message.author.id;
+
+  if (await has(kvKeys.IGNORED_USERS, authorId)) {
+    if (message.channel.isSendable()) {
+      await message.channel.send('You are already on the ignore list.');
+    }
+    return;
+  }
+
+  const { success, error } = await add(kvKeys.IGNORED_USERS, authorId, false);
+  if (!success) {
+    logger.error(`Failed to add user ${authorId} to ignore list:`, error);
+    if (message.channel.isSendable()) {
+      await message.channel.send(
+        'Could not update the ignore list. Please try again later.'
+      );
+    }
+    return;
+  }
+
+  logger.info(`User ${authorId} added themselves to the ignore list`);
+  if (message.channel.isSendable()) {
+    await message.channel.send(
+      'You are now on the ignore list. This bot will not process your messages or reactions. Send `.unignoreme` to opt back in.'
+    );
+  }
+};

--- a/src/events/messageCreate/index.ts
+++ b/src/events/messageCreate/index.ts
@@ -25,8 +25,29 @@ import { crawlChannelHistory, getCrawlStatus } from './crawlHistory';
 import lowCapacity from './forwarding/lowCapacity';
 import addDeleteReact from './addDeleteReact';
 import removeDeleteReact from './removeDeleteReact';
+import { isUserOnIgnoreList } from '../../utils/ignoreList';
+import { ignoreMe } from './ignoreMe';
+import { unignoreMe } from './unignoreMe';
 
 const messageCreate = async (message: Message) => {
+  const trimmed = message.content.trim();
+
+  if (await isUserOnIgnoreList(message.author.id)) {
+    if (trimmed === '.unignoreme' && !message.author.bot) {
+      return unignoreMe(message);
+    }
+    return;
+  }
+
+  if (!message.author.bot) {
+    if (trimmed === '.ignoreme') {
+      return ignoreMe(message);
+    }
+    if (trimmed === '.unignoreme') {
+      return unignoreMe(message);
+    }
+  }
+
   if (message.content.startsWith('.watchReacts')) {
     return withProtection(watchReacts)(message);
   } else if (message.content.startsWith('.unwatchReacts')) {

--- a/src/events/messageCreate/unignoreMe.test.ts
+++ b/src/events/messageCreate/unignoreMe.test.ts
@@ -1,0 +1,56 @@
+import { unignoreMe } from './unignoreMe';
+import { has, remove } from '../../utils/jsonAsDb/handlers/persistentList';
+
+jest.mock('../../utils/jsonAsDb/handlers/persistentList', () => ({
+  has: jest.fn(),
+  remove: jest.fn()
+}));
+
+const mockedHas = has as jest.MockedFunction<typeof has>;
+const mockedRemove = remove as jest.MockedFunction<typeof remove>;
+
+const makeMessage = (authorId: string) => {
+  const send = jest.fn().mockResolvedValue(undefined);
+  return {
+    author: { id: authorId, bot: false },
+    channel: { isSendable: () => true, send }
+  } as any;
+};
+
+describe('unignoreMe', () => {
+  beforeEach(() => {
+    mockedHas.mockReset();
+    mockedRemove.mockReset();
+  });
+
+  it('tells the user when not on the list', async () => {
+    mockedHas.mockResolvedValue(false);
+    const message = makeMessage('u1');
+    await unignoreMe(message);
+    expect(mockedRemove).not.toHaveBeenCalled();
+    expect(message.channel.send).toHaveBeenCalledWith(
+      'You are not on the ignore list.'
+    );
+  });
+
+  it('removes the user and confirms', async () => {
+    mockedHas.mockResolvedValue(true);
+    mockedRemove.mockResolvedValue({ success: true });
+    const message = makeMessage('u2');
+    await unignoreMe(message);
+    expect(mockedRemove).toHaveBeenCalled();
+    expect(message.channel.send).toHaveBeenCalledWith(
+      expect.stringContaining('You have been removed from the ignore list')
+    );
+  });
+
+  it('reports failure when remove does not succeed', async () => {
+    mockedHas.mockResolvedValue(true);
+    mockedRemove.mockResolvedValue({ success: false, error: 'disk full' });
+    const message = makeMessage('u3');
+    await unignoreMe(message);
+    expect(message.channel.send).toHaveBeenCalledWith(
+      'Could not update the ignore list. Please try again later.'
+    );
+  });
+});

--- a/src/events/messageCreate/unignoreMe.ts
+++ b/src/events/messageCreate/unignoreMe.ts
@@ -1,0 +1,33 @@
+import { Message } from 'discord.js';
+import { has, remove } from '../../utils/jsonAsDb/handlers/persistentList';
+import { kvKeys } from '../../utils/jsonAsDb/types';
+import logger from '../../utils/logger';
+
+export const unignoreMe = async (message: Message): Promise<void> => {
+  const authorId = message.author.id;
+
+  if (!(await has(kvKeys.IGNORED_USERS, authorId))) {
+    if (message.channel.isSendable()) {
+      await message.channel.send('You are not on the ignore list.');
+    }
+    return;
+  }
+
+  const { success, error } = await remove(kvKeys.IGNORED_USERS, authorId);
+  if (!success) {
+    logger.error(`Failed to remove user ${authorId} from ignore list:`, error);
+    if (message.channel.isSendable()) {
+      await message.channel.send(
+        'Could not update the ignore list. Please try again later.'
+      );
+    }
+    return;
+  }
+
+  logger.info(`User ${authorId} removed themselves from the ignore list`);
+  if (message.channel.isSendable()) {
+    await message.channel.send(
+      'You have been removed from the ignore list. This bot will process your messages and reactions again.'
+    );
+  }
+};

--- a/src/events/messageReactionAdd/onReactionForceRefetch.ts
+++ b/src/events/messageReactionAdd/onReactionForceRefetch.ts
@@ -26,12 +26,7 @@ export const onReactionForceRefetch = async (
   }
 
   // Skip this bot's own replies; allow webhooks and other bots (original link posts).
-  if (
-    shouldIgnoreOwnBotMessage(
-      message.author.id,
-      reaction.client.user?.id
-    )
-  ) {
+  if (shouldIgnoreOwnBotMessage(message.author.id, reaction.client.user?.id)) {
     return;
   }
 

--- a/src/events/messageReactionAdd/onReactionUndoWorldTag.test.ts
+++ b/src/events/messageReactionAdd/onReactionUndoWorldTag.test.ts
@@ -119,10 +119,7 @@ describe('onReactionUndoWorldTag', () => {
     const reaction = makeReaction();
     await onReactionUndoWorldTag(reaction, { bot: false } as any);
 
-    expect(remove).toHaveBeenCalledWith(
-      'PROCESSED_WORLDS',
-      WORLD_ID
-    );
+    expect(remove).toHaveBeenCalledWith('PROCESSED_WORLDS', WORLD_ID);
     expect(removeValue).toHaveBeenCalledWith(
       'PROCESSED_WORLDS_WITH_ORIGINAL_MESSAGE_ID',
       `${WORLD_ID}-guild1`

--- a/src/utils/ignoreList.test.ts
+++ b/src/utils/ignoreList.test.ts
@@ -1,0 +1,26 @@
+import { isUserOnIgnoreList } from './ignoreList';
+import { has } from './jsonAsDb/handlers/persistentList';
+import { kvKeys } from './jsonAsDb/types';
+
+jest.mock('./jsonAsDb/handlers/persistentList', () => ({
+  has: jest.fn()
+}));
+
+const mockedHas = has as jest.MockedFunction<typeof has>;
+
+describe('isUserOnIgnoreList', () => {
+  beforeEach(() => {
+    mockedHas.mockReset();
+  });
+
+  it('returns true when user id is in IGNORED_USERS', async () => {
+    mockedHas.mockResolvedValue(true);
+    await expect(isUserOnIgnoreList('user-1')).resolves.toBe(true);
+    expect(mockedHas).toHaveBeenCalledWith(kvKeys.IGNORED_USERS, 'user-1');
+  });
+
+  it('returns false when user id is not listed', async () => {
+    mockedHas.mockResolvedValue(false);
+    await expect(isUserOnIgnoreList('user-2')).resolves.toBe(false);
+  });
+});

--- a/src/utils/ignoreList.ts
+++ b/src/utils/ignoreList.ts
@@ -1,0 +1,6 @@
+import { has } from './jsonAsDb/handlers/persistentList';
+import { kvKeys } from './jsonAsDb/types';
+
+export async function isUserOnIgnoreList(userId: string): Promise<boolean> {
+  return has(kvKeys.IGNORED_USERS, userId);
+}

--- a/src/utils/jsonAsDb/types.ts
+++ b/src/utils/jsonAsDb/types.ts
@@ -25,7 +25,9 @@ export enum kvKeys {
   /** Message IDs that have already been force-refetched via recycle reaction (one refetch per message) */
   FORCE_REFETCHED_MESSAGE_IDS = 'FORCE_REFETCHED_MESSAGE_IDS',
   /** Emoji keys that delete the bot's own messages when reacted (in .watchReacts channels) */
-  REACT_TO_DELETE_EMOJIS = 'REACT_TO_DELETE_EMOJIS'
+  REACT_TO_DELETE_EMOJIS = 'REACT_TO_DELETE_EMOJIS',
+  /** Discord user IDs that opted out of message and reaction processing */
+  IGNORED_USERS = 'IGNORED_USERS'
 }
 
 /**


### PR DESCRIPTION


## Issue
Closes #54

## Description

Add IGNORED_USERS storage and .ignoreme / .unignoreme commands so users can opt out of bot processing. Ignored users skip all message handling except .unignoreme; their reactions are skipped at the reaction hub. Includes unit tests for ignore list helpers and commands.

Made-with: Cursor

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would change existing behavior)
- [ ] Chore / maintenance (deps, config, tooling, etc.)

## Checklist

- [x] Tests pass
- [x] No new warnings introduced
