### PR TITLE
feat: listReacts embed, camelCase ignore commands, manual & Cursor rules

### DIFF
--- a/.cursor/rules/bot-dot-commands.mdc
+++ b/.cursor/rules/bot-dot-commands.mdc
@@ -1,0 +1,23 @@
+---
+description: Dot-command docs and camelCase triggers when adding or changing Discord text commands
+globs:
+  - src/events/messageCreate/**/*.ts
+alwaysApply: false
+---
+
+# Bot dot-commands
+
+## Keep the manual in sync
+
+User-facing dot-commands are routed from `src/events/messageCreate/index.ts`. When you **add** a command, **change** its name, arguments, admin requirement, or behavior:
+
+- Update **`manual/commands.md`** (command tables, examples, routing notes such as order-sensitive prefixes).
+- If the same command is duplicated elsewhere for users (e.g. `README.md` or `src/events/messageCreate/README.md`), align those sections when the change is user-visible.
+
+## Trigger naming (camelCase)
+
+The token after the leading `.` must be **camelCase**: one lowercase word or several words with **no** separators—capitalize each segment after the first (e.g. `.watch`, `.exportFull`, `.forwardMaxSlots`, `.unwatchReacts`, `.ignoreMe`).
+
+Do **not** use snake_case, kebab-case, or PascalCase for the trigger (e.g. avoid `.forward_max_slots`, `.ForwardAndroid`).
+
+When ordering `startsWith` checks, longer prefixes must still be matched before shorter ones if they share a prefix (same as existing `.exportFull` before `.export`).

--- a/.cursor/rules/pull-requests.mdc
+++ b/.cursor/rules/pull-requests.mdc
@@ -1,0 +1,14 @@
+---
+description: Use the repo PR template when creating or drafting pull requests
+alwaysApply: true
+---
+
+# Pull requests
+
+When you are **asked to create a pull request** (including via `gh pr create`, drafting the PR body, or preparing text for the user to paste):
+
+1. Read **`.github/PULL_REQUEST_TEMPLATE.md`** and structure the description to match it.
+2. Fill **Issue** (`Closes #…` when there is a linked issue; otherwise state clearly that there is no tracking issue instead of leaving a placeholder like `#XX`).
+3. Complete **Description**, **Type of change** (check the right box or equivalent), and **Checklist** (only check items you have actually verified—run tests/lint when the checklist requires it).
+
+Do not submit or recommend a bare title-only PR body when the template expects these sections.

--- a/manual/commands.md
+++ b/manual/commands.md
@@ -20,8 +20,8 @@ This folder holds deeper documentation for how the bot behaves. This page is a *
 
 | Command | Admin | Description | Example |
 |--------|-------|-------------|---------|
-| `.ignoreme` | No | Adds you to the ignore list; the bot stops processing your messages and reactions until you opt back in. | `.ignoreme` |
-| `.unignoreme` | No | Removes you from the ignore list. While ignored, this is the **only** command the bot still handles for you. | `.unignoreme` |
+| `.ignoreMe` | No | Adds you to the ignore list; the bot stops processing your messages and reactions until you opt back in. | `.ignoreMe` |
+| `.unignoreMe` | No | Removes you from the ignore list. While ignored, this is the **only** command the bot still handles for you. | `.unignoreMe` |
 
 ### Channel watching
 
@@ -50,7 +50,7 @@ See [reaction-forwarding.md](reaction-forwarding.md) for setup and behavior deta
 | `.watchReacts` | Yes | Allow reactions in a channel to trigger emoji→channel forwarding (after mapping with `.forwardReact`). | `.watchReacts #channel` | `.watchReacts #inbox` |
 | `.unwatchReacts` | Yes | Stop watching a channel for reaction-based forwarding. | `.unwatchReacts #channel` | `.unwatchReacts #inbox` |
 | `.forwardReact` | Yes | Map an emoji to a destination; in watched react channels, that reaction forwards the message (once per message). | `.forwardReact <emoji> #channel` | `.forwardReact 📌 #saved` |
-| `.listReacts` | Yes | List emoji→channel mappings and react-to-delete emojis (with indices for removal). | `.listReacts` | `.listReacts` |
+| `.listReacts` | Yes | List channels with `.watchReacts`, emoji→channel mappings, and react-to-delete emojis (with indices for removal). | `.listReacts` | `.listReacts` |
 | `.removeReact` | Yes | Remove a forward mapping by emoji or by **1-based** index from `.listReacts`. | `.removeReact <emoji>` or `.removeReact <index>` | `.removeReact 1` |
 | `.addDeleteReact` | Yes | Register an emoji so reacting with it on **the bot’s messages** deletes them (in `.watchReacts` channels). | `.addDeleteReact <emoji>` | `.addDeleteReact 🗑️` |
 | `.removeDeleteReact` | Yes | Remove a react-to-delete emoji by emoji or **1-based** index (indices under **React to delete** in `.listReacts`). | `.removeDeleteReact <emoji>` or `.removeDeleteReact <index>` | `.removeDeleteReact 🗑️` |

--- a/manual/commands.md
+++ b/manual/commands.md
@@ -1,0 +1,81 @@
+# Manual — VRC World Tagger Bot
+
+This folder holds deeper documentation for how the bot behaves. This page is a **quick reference for Discord dot-commands**: what they do, who can use them, and copy-paste-style examples.
+
+## Related docs
+
+- [World link processing](world-link-processing.md) — detection, duplicates, embeds, criteria-based forwarding (with diagrams).
+- [Reaction forwarding](reaction-forwarding.md) — emoji→channel forwarding, react-to-delete, handler flows (with diagrams).
+
+## How commands work
+
+- Send commands as normal messages in a **text channel** the bot can read.
+- **Admin commands** require your Discord user ID in the `ADMIN_ID` environment variable (comma-separated). If you are not an admin, protected commands are **silently ignored** (no reply).
+- When a command needs a channel, **mention it** with `#`. The bot uses the **first channel mention** in the message.
+- **Routing note:** `.exportFull` is matched before `.export`, so messages must start with `.exportFull` for the full export (not `.export` with extra text).
+
+## Command list
+
+### Opt out / opt in (any user, not bots)
+
+| Command | Admin | Description | Example |
+|--------|-------|-------------|---------|
+| `.ignoreme` | No | Adds you to the ignore list; the bot stops processing your messages and reactions until you opt back in. | `.ignoreme` |
+| `.unignoreme` | No | Removes you from the ignore list. While ignored, this is the **only** command the bot still handles for you. | `.unignoreme` |
+
+### Channel watching
+
+| Command | Admin | Description | Usage | Example |
+|--------|-------|-------------|-------|---------|
+| `.watch` | Yes | Watch a channel for VRChat world links (embeds, duplicate tracking, automatic forwarding). | `.watch #channel` | `.watch #vrchat-worlds` |
+| `.unwatch` | Yes | Stop watching a channel for world links. | `.unwatch #channel` | `.unwatch #vrchat-worlds` |
+
+### Automatic forwarding (world criteria)
+
+Each command sets **one** destination for that rule. A single world can match several rules and be forwarded to **several** channels in one pass.
+
+| Command | Admin | Description | Usage | Example |
+|--------|-------|-------------|-------|---------|
+| `.forwardAndroid` | Yes | Forward worlds with Android/Quest support to a channel. | `.forwardAndroid #channel` | `.forwardAndroid #android-worlds` |
+| `.forwardMaxSlots` | Yes | Forward high-capacity worlds (capacity ≥ `FORWARD_PLAYER_COUNT_THRESHOLD`, default 40). | `.forwardMaxSlots #channel` | `.forwardMaxSlots #big-venues` |
+| `.forwardLowCap` | Yes | Forward low-capacity worlds (capacity ≤ `LOW_CAPACITY_THRESHOLD`, default 20). | `.forwardLowCap #channel` | `.forwardLowCap #small-worlds` |
+| `.clearForwardingChannels` | Yes | Clear all automatic forwarding destinations (Android, high-cap, low-cap). Does **not** change watched channels or reaction settings. | `.clearForwardingChannels` | `.clearForwardingChannels` |
+
+### Reaction forwarding and cleanup
+
+See [reaction-forwarding.md](reaction-forwarding.md) for setup and behavior details.
+
+| Command | Admin | Description | Usage | Example |
+|--------|-------|-------------|-------|---------|
+| `.watchReacts` | Yes | Allow reactions in a channel to trigger emoji→channel forwarding (after mapping with `.forwardReact`). | `.watchReacts #channel` | `.watchReacts #inbox` |
+| `.unwatchReacts` | Yes | Stop watching a channel for reaction-based forwarding. | `.unwatchReacts #channel` | `.unwatchReacts #inbox` |
+| `.forwardReact` | Yes | Map an emoji to a destination; in watched react channels, that reaction forwards the message (once per message). | `.forwardReact <emoji> #channel` | `.forwardReact 📌 #saved` |
+| `.listReacts` | Yes | List emoji→channel mappings and react-to-delete emojis (with indices for removal). | `.listReacts` | `.listReacts` |
+| `.removeReact` | Yes | Remove a forward mapping by emoji or by **1-based** index from `.listReacts`. | `.removeReact <emoji>` or `.removeReact <index>` | `.removeReact 1` |
+| `.addDeleteReact` | Yes | Register an emoji so reacting with it on **the bot’s messages** deletes them (in `.watchReacts` channels). | `.addDeleteReact <emoji>` | `.addDeleteReact 🗑️` |
+| `.removeDeleteReact` | Yes | Remove a react-to-delete emoji by emoji or **1-based** index (indices under **React to delete** in `.listReacts`). | `.removeDeleteReact <emoji>` or `.removeDeleteReact <index>` | `.removeDeleteReact 🗑️` |
+
+### World data and history
+
+| Command | Admin | Description | Usage | Example |
+|--------|-------|-------------|-------|---------|
+| `.export` | No | Export a CSV of processed world IDs and URLs (no live VRChat API call per world). | `.export` | `.export` |
+| `.exportFull` | Yes | Export a detailed CSV with live VRChat API data per world; rate-limited and heavier. | `.exportFull` | `.exportFull` |
+| `.crawlHistory` | Yes | Scan a channel’s history for world links and process them with duplicate logic. | `.crawlHistory #channel` | `.crawlHistory #vrchat-worlds` |
+| `.crawlStatus` | No | Show crawl progress or completion for a channel. | `.crawlStatus #channel` | `.crawlStatus #vrchat-worlds` |
+
+### Maintenance
+
+| Command | Admin | Description | Usage | Example |
+|--------|-------|-------------|-------|---------|
+| `.stats` | No | Show bot statistics (**only** in channels that are watched with `.watch`). | `.stats` | `.stats` |
+| `.remove` | Yes | In a **watched** channel, clear duplicate tracking for a world whose link appears in the message so it can be treated as new again in this guild. Does not unwatch or delete forwarded copies. | `.remove` + world URL in the same message | `.remove https://vrchat.com/home/world/wrld_...` |
+| `.die` | Yes | Shut down the bot process gracefully. | `.die` | `.die` |
+
+## Anything that is not a command
+
+Messages that do **not** start with one of the prefixes above are handled as normal content: in watched channels, the bot runs world-link detection, embeds, duplicates, and forwarding as documented in [world-link-processing.md](world-link-processing.md).
+
+## Project README
+
+Installation, environment variables, and scripts are in the repository root [README.md](../README.md).

--- a/src/events/messageCreate/forwarding/listReacts.ts
+++ b/src/events/messageCreate/forwarding/listReacts.ts
@@ -5,11 +5,14 @@ import { kvKeys } from '../../../utils/jsonAsDb/types';
 
 type ReactionForwardConfig = Record<string, string>;
 
+const MAX_WATCHED_LINES = 18;
+
 const listReacts = async (message: Message) => {
   const config =
     (await get<ReactionForwardConfig>(kvKeys.REACTION_FORWARD_CHANNELS)) || {};
   const forwardEntries = Object.entries(config);
   const deleteEmojis = await getAll(kvKeys.REACT_TO_DELETE_EMOJIS);
+  const watchedChannelIds = await getAll(kvKeys.WATCHED_REACTION_CHANNELS);
 
   if (!message.channel.isSendable()) return;
 
@@ -17,7 +20,9 @@ const listReacts = async (message: Message) => {
     .setColor(0x0099ff)
     .setTitle('Reaction actions');
 
-  if (forwardEntries.length === 0 && deleteEmojis.length === 0) {
+  const hasRules = forwardEntries.length > 0 || deleteEmojis.length > 0;
+
+  if (!hasRules && watchedChannelIds.length === 0) {
     embed.setDescription(
       'No reaction actions are configured.\n\n' +
         '• **Forwarding** — `.forwardReact <emoji> #channel`\n' +
@@ -27,9 +32,40 @@ const listReacts = async (message: Message) => {
     return;
   }
 
-  embed.setDescription(
-    'These only run in channels where `.watchReacts` is enabled.'
-  );
+  const watchLinesShown = watchedChannelIds.slice(0, MAX_WATCHED_LINES);
+  const watchFieldLines =
+    watchedChannelIds.length === 0
+      ? [
+          '_No channels — use `.watchReacts #channel` (mention the channel) to enable reaction handling there._'
+        ]
+      : watchLinesShown.map(
+          (id, i) => `${i + 1}. ${channelMention(id)}`
+        );
+  if (watchedChannelIds.length > MAX_WATCHED_LINES) {
+    watchFieldLines.push(
+      `_…and ${watchedChannelIds.length - MAX_WATCHED_LINES} more._`
+    );
+  }
+  if (watchedChannelIds.length > 0) {
+    watchFieldLines.push(
+      '_Use `.unwatchReacts #channel` to stop watching a channel._'
+    );
+  }
+
+  if (!hasRules) {
+    embed.setDescription(
+      'No emoji rules yet. Add forwarding with `.forwardReact` or delete-on-react with `.addDeleteReact`.'
+    );
+  } else {
+    embed.setDescription(
+      'Forwarding and react-to-delete run only in the channels listed under **Watching**.'
+    );
+  }
+
+  embed.addFields({
+    name: 'Watching for reactions',
+    value: watchFieldLines.join('\n')
+  });
 
   if (forwardEntries.length > 0) {
     const lines = forwardEntries.map(

--- a/src/events/messageCreate/forwarding/listReacts.ts
+++ b/src/events/messageCreate/forwarding/listReacts.ts
@@ -38,9 +38,7 @@ const listReacts = async (message: Message) => {
       ? [
           '_No channels — use `.watchReacts #channel` (mention the channel) to enable reaction handling there._'
         ]
-      : watchLinesShown.map(
-          (id, i) => `${i + 1}. ${channelMention(id)}`
-        );
+      : watchLinesShown.map((id, i) => `${i + 1}. ${channelMention(id)}`);
   if (watchedChannelIds.length > MAX_WATCHED_LINES) {
     watchFieldLines.push(
       `_…and ${watchedChannelIds.length - MAX_WATCHED_LINES} more._`

--- a/src/events/messageCreate/ignoreMe.ts
+++ b/src/events/messageCreate/ignoreMe.ts
@@ -27,7 +27,7 @@ export const ignoreMe = async (message: Message): Promise<void> => {
   logger.info(`User ${authorId} added themselves to the ignore list`);
   if (message.channel.isSendable()) {
     await message.channel.send(
-      'You are now on the ignore list. This bot will not process your messages or reactions. Send `.unignoreme` to opt back in.'
+      'You are now on the ignore list. This bot will not process your messages or reactions. Send `.unignoreMe` to opt back in.'
     );
   }
 };

--- a/src/events/messageCreate/index.ts
+++ b/src/events/messageCreate/index.ts
@@ -33,17 +33,17 @@ const messageCreate = async (message: Message) => {
   const trimmed = message.content.trim();
 
   if (await isUserOnIgnoreList(message.author.id)) {
-    if (trimmed === '.unignoreme' && !message.author.bot) {
+    if (trimmed === '.unignoreMe' && !message.author.bot) {
       return unignoreMe(message);
     }
     return;
   }
 
   if (!message.author.bot) {
-    if (trimmed === '.ignoreme') {
+    if (trimmed === '.ignoreMe') {
       return ignoreMe(message);
     }
-    if (trimmed === '.unignoreme') {
+    if (trimmed === '.unignoreMe') {
       return unignoreMe(message);
     }
   }


### PR DESCRIPTION
## Issue

No linked tracking issue.

## Description

- **`.listReacts`**: Embed lists channels where `.watchReacts` is enabled (truncated after 18 lines with overflow text), clearer empty states when no emoji rules exist vs nothing configured, and a **Watching for reactions** field with updated descriptions.
- **Command triggers**: Opt-out commands use camelCase — **`.ignoreMe`** and **`.unignoreMe`** (replacing `.ignoreme` / `.unignoreme`). Existing users or scripts must use the new spelling.
- **Docs**: Add **`manual/commands.md`** as a dot-command quick reference (including ignore commands and `.listReacts`).
- **Cursor rules**: Add `.cursor/rules/bot-dot-commands.mdc` (keep `manual/commands.md` in sync; camelCase dot-command triggers) and `.cursor/rules/pull-requests.mdc` (follow `.github/PULL_REQUEST_TEMPLATE.md` when opening PRs).

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [x] Breaking change (fix or feature that would change existing behavior)
- [x] Chore / maintenance (deps, config, tooling, etc.)

## Checklist

- [x] Tests pass
- [x] No new warnings introduced
