### PR TITLE
[FEAT]: handle multiple worlds in 1 message

### DIFF
--- a/src/events/messageCreate/watchForVRCWorldLinks/index.ts
+++ b/src/events/messageCreate/watchForVRCWorldLinks/index.ts
@@ -8,7 +8,7 @@ import {
   setValue
 } from '../../../utils/jsonAsDb/handlers/persistentKvp';
 import { kvKeys } from '../../../utils/jsonAsDb/types';
-import { extractWorldIdFromMessage } from './worldExtraction';
+import { extractWorldIdFromMessage, extractAllWorldIdsFromMessage } from './worldExtraction';
 import { fetchWorldData, calculatePackageSizes } from './worldData';
 import { createWorldEmbed } from './embedBuilder';
 import {
@@ -115,34 +115,81 @@ const findFirstWorldMatch = async (
   return null;
 };
 
+/**
+ * Finds all world links in the message body, forwarded snapshots, and attachments.
+ * When `scanAttachmentFilenames` is true, attachment file names are checked last.
+ */
+const findAllWorldMatches = async (
+  message: Message,
+  scanAttachmentFilenames: boolean
+): Promise<WorldMatch[]> => {
+  const matches: WorldMatch[] = [];
+  const seen = new Set<string>();
+
+  if (message.content) {
+    logger.debug(
+      `Checking direct message content: ${message.content.substring(0, 100)}...`
+    );
+    const fromBody = await extractAllWorldIdsFromMessage(message.content);
+    for (const { worldId, sourceContent } of fromBody) {
+      if (!seen.has(worldId)) {
+        seen.add(worldId);
+        matches.push({
+          worldId,
+          sourceContent,
+          sourceKind: 'body'
+        });
+      }
+    }
+  }
+
+  if (message.messageSnapshots && message.messageSnapshots.size > 0) {
+    logger.debug(
+      `Found ${message.messageSnapshots.size} forwarded message snapshots`
+    );
+    for (const [, snapshot] of message.messageSnapshots) {
+      if (!snapshot.content) continue;
+      logger.debug(
+        `Checking forwarded snapshot content: ${snapshot.content.substring(0, 100)}...`
+      );
+      const fromSnapshot = await extractAllWorldIdsFromMessage(snapshot.content);
+      for (const { worldId, sourceContent } of fromSnapshot) {
+        if (!seen.has(worldId)) {
+          seen.add(worldId);
+          matches.push({
+            worldId,
+            sourceContent,
+            sourceKind: 'snapshot'
+          });
+        }
+      }
+    }
+  }
+
+  if (scanAttachmentFilenames) {
+    for (const attachment of eachAttachment(message)) {
+      const ids = extractAllWorldIds(attachment.name ?? '');
+      for (const worldId of ids) {
+        if (!seen.has(worldId)) {
+          seen.add(worldId);
+          matches.push({
+            worldId,
+            sourceContent: attachment.name ?? worldId,
+            sourceKind: 'attachment'
+          });
+        }
+      }
+    }
+  }
+
+  return matches;
+};
+
 const buildWorldProcessQueue = async (
   message: Message,
   scanAttachmentFilenames: boolean
 ): Promise<WorldMatch[]> => {
-  const primary = await findFirstWorldMatch(message, scanAttachmentFilenames);
-  const fromFilenames = scanAttachmentFilenames
-    ? attachmentWorldIdsInOrder(message)
-    : [];
-  const seen = new Set<string>();
-  const queue: WorldMatch[] = [];
-
-  if (primary) {
-    queue.push(primary);
-    seen.add(primary.worldId);
-  }
-
-  for (const worldId of fromFilenames) {
-    if (!seen.has(worldId)) {
-      seen.add(worldId);
-      queue.push({
-        worldId,
-        sourceContent: attachmentDisplayNameForWorldId(message, worldId),
-        sourceKind: 'attachment'
-      });
-    }
-  }
-
-  return queue;
+  return findAllWorldMatches(message, scanAttachmentFilenames);
 };
 
 /**

--- a/src/events/messageCreate/watchForVRCWorldLinks/worldExtraction/index.ts
+++ b/src/events/messageCreate/watchForVRCWorldLinks/worldExtraction/index.ts
@@ -5,7 +5,10 @@ import {
   getLinkFromMessage,
   extractWithCustomMatcher,
   removeLinksFromTweet,
-  extractWorldAndAuthor
+  extractWorldAndAuthor,
+  extractAllWorldIds,
+  extractAllLinks,
+  isTwitterLink
 } from '../../../../utils/regex';
 import { searchByWorldName } from '../../../../utils/externalApi/vrchat';
 import getTweetContent from '../../../../utils/externalApi/vxtwitter';
@@ -14,27 +17,63 @@ import { closest, distance } from 'fastest-levenshtein';
 import logger from '../../../../utils/logger';
 
 /**
- * Extracts world ID from message content or Twitter links
+ * Extracts all world IDs from message content, including resolving Twitter links.
+ * Returns world IDs in order of first appearance, deduplicated.
+ */
+export const extractAllWorldIdsFromMessage = async (
+  content: string
+): Promise<{ worldId: string; sourceContent: string }[]> => {
+  const results: { worldId: string; sourceContent: string }[] = [];
+  const seen = new Set<string>();
+
+  // 1. Direct world IDs
+  const directIds = extractAllWorldIds(content);
+  for (const worldId of directIds) {
+    if (!seen.has(worldId)) {
+      seen.add(worldId);
+      results.push({ worldId, sourceContent: content });
+    }
+  }
+
+  // 2. Twitter links
+  const links = extractAllLinks(content);
+  for (const link of links) {
+    if (!isTwitterLink(link)) continue;
+
+    const tweetContent = await getTweetContent(link);
+    if (!tweetContent) continue;
+
+    // Try direct world ID(s) in tweet first
+    const tweetWorldIds = extractAllWorldIds(tweetContent);
+    if (tweetWorldIds.length > 0) {
+      for (const worldId of tweetWorldIds) {
+        if (!seen.has(worldId)) {
+          seen.add(worldId);
+          results.push({ worldId, sourceContent: tweetContent });
+        }
+      }
+      continue;
+    }
+
+    // Fall back to parsing world name/author from tweet
+    const worldIdFromText = await parseWorldInfoFromPlainText(link, tweetContent);
+    if (worldIdFromText && !seen.has(worldIdFromText)) {
+      seen.add(worldIdFromText);
+      results.push({ worldId: worldIdFromText, sourceContent: tweetContent });
+    }
+  }
+
+  return results;
+};
+
+/**
+ * Extracts world ID from message content or Twitter links (first match only)
  */
 export const extractWorldIdFromMessage = async (
   content: string
 ): Promise<string | null> => {
-  const directWorldId = extractWorldId(content);
-  if (directWorldId) {
-    return directWorldId;
-  }
-
-  const twitterLink = getLinkFromMessage(content);
-  if (twitterLink) {
-    const tweetContent = await getTweetContent(twitterLink);
-    const worldIdFromTwitterLink = extractWorldId(tweetContent);
-
-    if (worldIdFromTwitterLink) return worldIdFromTwitterLink;
-
-    // Try to parse the world data from the tweet content
-    return parseWorldInfoFromPlainText(twitterLink, tweetContent);
-  }
-  return null;
+  const all = await extractAllWorldIdsFromMessage(content);
+  return all[0]?.worldId ?? null;
 };
 
 /**

--- a/src/utils/regex/index.ts
+++ b/src/utils/regex/index.ts
@@ -145,6 +145,24 @@ export function getLinkFromMessage(message: string): string | null {
   return match?.[0] ?? null;
 }
 
+/**
+ * Returns every HTTP(S) link found in `text`, in order of first appearance.
+ */
+export function extractAllLinks(text: string): string[] {
+  if (!text) return [];
+  const re = new RegExp(GENERIC_LINK_REGEX.source, 'g');
+  const matches = text.match(re);
+  return matches ?? [];
+}
+
+/**
+ * Checks whether a link points to a known Twitter/X domain.
+ */
+export function isTwitterLink(link: string): boolean {
+  if (!link) return false;
+  return TWITTER_LINK_REGEX.test(link);
+}
+
 export function removeTwitterLink(link: string): string | null {
   if (!link) return null;
   const match = link.match(TWITTER_LINK_REGEX);

--- a/src/utils/regex/regex.test.ts
+++ b/src/utils/regex/regex.test.ts
@@ -5,7 +5,9 @@ import {
   extractWorldAndAuthor,
   customMatchers,
   extractWithCustomMatcher,
-  extractAllWorldIds
+  extractAllWorldIds,
+  extractAllLinks,
+  isTwitterLink
 } from './index';
 
 // Mock the config to avoid environment variable dependencies
@@ -620,6 +622,42 @@ describe('regex', () => {
       const noWorldData = `Just some random text\n#VRChat`;
       const result = extractWorldAndAuthor(noWorldData);
       expect(result).toBeNull();
+    });
+  });
+
+  describe('extractAllLinks', () => {
+    it('returns empty for empty or non-matching text', () => {
+      expect(extractAllLinks('')).toEqual([]);
+      expect(extractAllLinks('no links here')).toEqual([]);
+    });
+
+    it('returns all links in first-appearance order', () => {
+      expect(
+        extractAllLinks('check https://a.com and https://b.com/foo')
+      ).toEqual(['https://a.com', 'https://b.com/foo']);
+    });
+
+    it('finds multiple twitter/x links', () => {
+      expect(
+        extractAllLinks(
+          'https://x.com/a/status/1 https://x.com/b/status/2'
+        )
+      ).toEqual(['https://x.com/a/status/1', 'https://x.com/b/status/2']);
+    });
+  });
+
+  describe('isTwitterLink', () => {
+    it('returns true for twitter/x domains', () => {
+      expect(isTwitterLink('https://twitter.com/user/status/1')).toBe(true);
+      expect(isTwitterLink('https://x.com/user/status/1')).toBe(true);
+      expect(isTwitterLink('https://fixupx.com/user/status/1')).toBe(true);
+      expect(isTwitterLink('https://vxtwitter.com/user/status/1')).toBe(true);
+    });
+
+    it('returns false for non-twitter domains', () => {
+      expect(isTwitterLink('https://example.com')).toBe(false);
+      expect(isTwitterLink('https://vrchat.com')).toBe(false);
+      expect(isTwitterLink('')).toBe(false);
     });
   });
 


### PR DESCRIPTION
## Issue
Closes #XX

## Description

Adds functionality for the bot to handle multiple world links in 1 message. This functionality already existed with multiple attachments.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would change existing behavior)
- [ ] Chore / maintenance (deps, config, tooling, etc.)

## Checklist

- [x] Tests pass
- [x] No new warnings introduced
