### PR TITLE
fix(crawlHistory): skip bot's own messages and ignored users

### DIFF
--- a/src/events/messageCreate/crawlHistory.ts
+++ b/src/events/messageCreate/crawlHistory.ts
@@ -1,5 +1,7 @@
 import { Message, GuildTextBasedChannel } from 'discord.js';
 import logger from '../../utils/logger';
+import { shouldIgnoreOwnBotMessage } from '../../botFilters';
+import { isUserOnIgnoreList } from '../../utils/ignoreList';
 import { getAll } from '../../utils/jsonAsDb/handlers/persistentList';
 import { set, get as getValue } from '../../utils/jsonAsDb/index';
 import { kvKeys, CrawlStatus } from '../../utils/jsonAsDb/types';
@@ -459,6 +461,16 @@ const crawlMessages = async (
         logger.info(
           `Crawling message ${totalMessages}: ${msg.id} at ${msg.createdAt.toISOString()}`
         );
+
+        // Skip bot's own messages and ignored users
+        if (shouldIgnoreOwnBotMessage(msg.author.id, msg.client.user?.id)) {
+          logger.debug(`Skipping message ${msg.id}: bot's own message`);
+          continue;
+        }
+        if (await isUserOnIgnoreList(msg.author.id)) {
+          logger.debug(`Skipping message ${msg.id}: author is on ignore list`);
+          continue;
+        }
 
         // ── DISCOVER MODE ──
         if (mode === 'discover') {


### PR DESCRIPTION
## Summary

The `.crawlHistory` command was processing all messages in channel history, including messages posted by the bot itself and messages from users who have opted out via `.ignoreMe`.

## Changes

- Skip the bot's own messages during crawl, reusing the existing `shouldIgnoreOwnBotMessage` helper.
- Skip messages from users on the ignore list, reusing the existing `isUserOnIgnoreList` helper.
- Both filters are applied inside the per-message loop in `crawlMessages` before any mode-specific processing (discover / tags / quality).

## Testing

All 189 tests pass. TypeScript compiles cleanly.