### PR TITLE
[FIX]: align tag extraction with normal message processing

### DIFF
--- a/src/events/messageCreate/crawlHistory.ts
+++ b/src/events/messageCreate/crawlHistory.ts
@@ -9,6 +9,7 @@ import {
   extractAllWorldIdsFromMessage,
   extractWorldIdFromMessage
 } from './watchForVRCWorldLinks/worldExtraction';
+import { buildTagSource } from './watchForVRCWorldLinks';
 import { extractWorldId } from '../../utils/regex';
 import { checkAndHandleDuplicate } from './watchForVRCWorldLinks/duplicateHandler';
 import { emojiMap } from '../../assets/media';
@@ -480,8 +481,8 @@ const crawlMessages = async (
         // ── TAGS MODE ──
         else if (mode === 'tags') {
           const result = await handleTagsMode(msg, processedWorldsCache, repo);
-          if (result.updated) recordsUpdated++;
-          if (result.notFound) recordsNotFound++;
+          recordsUpdated += result.updated;
+          recordsNotFound += result.notFound;
         }
 
         // ── QUALITY MODE ──
@@ -622,13 +623,13 @@ async function handleDiscoverMode(
 
 /**
  * Handle a single message in tags mode.
- * Returns whether the record was updated and whether it was not found.
+ * Returns counts of updated and not-found records.
  */
 async function handleTagsMode(
   msg: Message,
   processedWorldsCache: Set<string>,
   repo: ReturnType<typeof getWorldRepository>
-): Promise<{ updated: boolean; notFound: boolean }> {
+): Promise<{ updated: number; notFound: number }> {
   // Extract world ID + source content (resolves Twitter links)
   let allResults = await extractAllWorldIdsFromMessage(msg.content);
 
@@ -642,34 +643,49 @@ async function handleTagsMode(
     }
   }
 
-  const firstResult = allResults[0];
-
-  if (!firstResult) {
+  if (allResults.length === 0) {
     logger.debug(`No world found in message ${msg.id} for tag rebuild`);
-    return { updated: false, notFound: false };
+    return { updated: 0, notFound: 0 };
   }
 
-  const { worldId, sourceContent } = firstResult;
-  const cacheKey = `${worldId}-${msg.guildId}`;
+  // Build tag source from all message sources, exactly like normal processing
+  const tagSource = buildTagSource(
+    msg,
+    allResults.map((r) => r.sourceContent)
+  );
+  const tags = extractTags(tagSource);
 
-  if (!processedWorldsCache.has(cacheKey)) {
-    logger.warn(
-      `Skipping message ${msg.id}: world ${worldId} not in database (tags mode)`
+  let updated = 0;
+  let notFound = 0;
+
+  for (const { worldId, sourceContent } of allResults) {
+    const cacheKey = `${worldId}-${msg.guildId}`;
+
+    if (!processedWorldsCache.has(cacheKey)) {
+      logger.warn(
+        `Skipping message ${msg.id}: world ${worldId} not in database (tags mode)`
+      );
+      notFound++;
+      continue;
+    }
+
+    const didUpdate = repo.updateTags(
+      worldId,
+      msg.guildId!,
+      tags,
+      sourceContent
     );
-    return { updated: false, notFound: true };
-  }
 
-  const tags = extractTags(sourceContent);
-  const didUpdate = repo.updateTags(worldId, msg.guildId!, tags, sourceContent);
-
-  if (didUpdate) {
-    logger.info(
-      `Rebuilt tags for ${worldId}: [${tags.join(', ')}] from message ${msg.id}`
-    );
+    if (didUpdate) {
+      logger.info(
+        `Rebuilt tags for ${worldId}: [${tags.join(', ')}] from message ${msg.id}`
+      );
+      updated++;
+    }
   }
 
   await delay(RATE_LIMIT_DELAY);
-  return { updated: didUpdate, notFound: false };
+  return { updated, notFound };
 }
 
 /**

--- a/src/events/messageCreate/watchForVRCWorldLinks/index.ts
+++ b/src/events/messageCreate/watchForVRCWorldLinks/index.ts
@@ -179,6 +179,29 @@ const buildWorldProcessQueue = async (
 };
 
 /**
+ * Build the combined text source for tag extraction from a Discord message
+ * and any resolved external content (e.g. tweet text). This mirrors the
+ * logic used in normal message processing so that crawlHistory extracts
+ * tags from the same sources.
+ */
+export function buildTagSource(
+  message: Message,
+  extraSources: (string | null | undefined)[]
+): string {
+  const tagParts = new Set<string>();
+  if (message.content) tagParts.add(message.content);
+  if (message.messageSnapshots) {
+    for (const [, snapshot] of message.messageSnapshots) {
+      if (snapshot.content) tagParts.add(snapshot.content);
+    }
+  }
+  for (const source of extraSources) {
+    if (source) tagParts.add(source);
+  }
+  return cleanContentForTagExtraction(Array.from(tagParts).join('\n'));
+}
+
+/**
  * Processes a world ID: fetches data, extracts tags, upserts to repository,
  * creates embed, sends the bot reply, then forwards it.
  */
@@ -203,18 +226,7 @@ const processWorldId = async (
   const supportedPlatforms = getSupportedPlatforms(worldData.unityPackages);
   const packageSizes = await calculatePackageSizes(worldData);
 
-  const tagParts = new Set<string>();
-  if (message.content) tagParts.add(message.content);
-  if (message.messageSnapshots) {
-    for (const [, snapshot] of message.messageSnapshots) {
-      if (snapshot.content) tagParts.add(snapshot.content);
-    }
-  }
-  if (sourceContent) tagParts.add(sourceContent);
-
-  const tagSource = cleanContentForTagExtraction(
-    Array.from(tagParts).join('\n')
-  );
+  const tagSource = buildTagSource(message, [sourceContent]);
   const tags = extractTags(tagSource);
 
   const record: WorldRecord = {


### PR DESCRIPTION
## Problem

`.crawlHistory --tags` was extracting tags from the **resolved tweet text** (`sourceContent`) rather than the **Discord message content**. This caused tags like `Tags: chill, kino?` posted in Discord to be completely ignored during crawls, and existing tags to be silently overwritten with `[]`.

## Changes

- Extract shared `buildTagSource()` helper in `watchForVRCWorldLinks/index.ts`
- Use it in both `processWorldId` (normal flow) and `handleTagsMode` (crawl)
- `handleTagsMode` now processes **all** world matches in a message, not just the first one, matching normal processing behavior
- Return numeric counts so progress tracking accumulates correctly across multi-world messages

## Verification

- TypeScript compiles cleanly
- All 189 tests pass