### PR TITLE
[FIX]: extract inline tags without 'Tags:' prefix

### DIFF
--- a/src/utils/regex/index.ts
+++ b/src/utils/regex/index.ts
@@ -381,7 +381,9 @@ export function cleanContentForTagExtraction(content: string): string {
   return content
     .replace(/https?:\/\/[^\s]+|www\.[^\s]+/gi, ' ')
     .replace(/wrld_[a-f0-9-]{36}/gi, ' ')
-    .replace(/\s+/g, ' ')
+    .replace(/[ \t]+/g, ' ') // collapse horizontal whitespace only
+    .replace(/\n[ \t]*/g, '\n') // trim leading spaces from each line
+    .replace(/[ \t]*\n/g, '\n') // trim trailing spaces from each line
     .trim();
 }
 

--- a/src/utils/tagExtractor/index.ts
+++ b/src/utils/tagExtractor/index.ts
@@ -68,7 +68,7 @@ function extractStructuredTags(content: string): string[] {
       const whole = afterPrefix
         .toLowerCase()
         .replace(/^[([{'"`]+/, '')
-        .replace(/[)\]}'"`]+$/, '');
+        .replace(/[)\]}'"`?.!]+$/, '');
       const wholeValidated = validate(whole);
       if (wholeValidated && !seen.has(wholeValidated)) {
         seen.add(wholeValidated);
@@ -79,7 +79,7 @@ function extractStructuredTags(content: string): string[] {
       const tokens = afterPrefix
         .split(/[,，、\s]+/)
         .map((t) => t.trim().toLowerCase())
-        .map((t) => t.replace(/^[([{'"`]+/, '').replace(/[)\]}'"`]+$/, ''))
+        .map((t) => t.replace(/^[([{'"`]+/, '').replace(/[)\]}'"`?.!]+$/, ''))
         .filter((t) => t.length > 0);
 
       for (const token of tokens) {
@@ -110,10 +110,15 @@ function validate(token: string): string | null {
 }
 
 /**
- * Main entry point: extract validated taxonomy tags from structured tag lines.
+ * Main entry point: extract validated taxonomy tags from message content.
  *
- * Looks for lines starting with known prefixes (Tags:, Tag:, Category:, etc.)
- * and validates the comma/space-separated tokens against the taxonomy.
+ * Pass 1 – structured lines: looks for lines starting with known prefixes
+ * (Tags:, Tag:, Category:, etc.) and validates the tokens against the taxonomy.
+ *
+ * Pass 2 – unstructured "pure tag" lines: any line whose tokens are *all*
+ * valid taxonomy terms (after stripping punctuation) is also accepted.
+ * This handles messages like "https://... kino, chill" where the tags
+ * appear inline without a prefix.
  */
 export function extractTags(content: string): string[] {
   if (!content || typeof content !== 'string') {
@@ -123,6 +128,7 @@ export function extractTags(content: string): string[] {
   const seen = new Set<string>();
   const result: string[] = [];
 
+  // ── Pass 1: structured prefix lines ──
   for (const token of extractStructuredTags(content)) {
     const validated = validate(token);
     if (!validated) continue;
@@ -130,6 +136,41 @@ export function extractTags(content: string): string[] {
 
     seen.add(validated);
     result.push(validated);
+  }
+
+  // ── Pass 2: unstructured lines that consist entirely of taxonomy terms ──
+  const lines = content.split(/\r?\n/);
+  for (const rawLine of lines) {
+    const line = rawLine.trim();
+    if (!line) continue;
+
+    // Skip lines that look like they have a structured prefix (already handled)
+    // by checking if they start with a known prefix pattern.
+    const hasPrefix = ALL_PREFIXES.some((p) => p.test(line));
+    if (hasPrefix) continue;
+
+    const tokens = line
+      .split(/[,，、\s]+/)
+      .map((t) => t.trim().toLowerCase())
+      .map((t) => t.replace(/^[([{'"`]+/, '').replace(/[)\]}'"`?.!]+$/, ''))
+      .filter((t) => t.length > 0);
+
+    if (tokens.length === 0) continue;
+
+    // Only accept lines where a majority of tokens are valid taxonomy terms,
+    // and at least one token is valid. This handles lines like
+    // "meme game (little) horror" where most words are tags but a few
+    // aren't (e.g. descriptors in parentheses).
+    const validTokens = tokens.filter((t) => validate(t) !== null);
+    const validRatio = validTokens.length / tokens.length;
+    if (validTokens.length === 0 || validRatio < 0.5) continue;
+
+    for (const token of validTokens) {
+      const validated = validate(token)!;
+      if (seen.has(validated)) continue;
+      seen.add(validated);
+      result.push(validated);
+    }
   }
 
   logger.debug(`Extracted tags from content: ${JSON.stringify(result)}`);

--- a/src/utils/tagExtractor/tagExtractor.test.ts
+++ b/src/utils/tagExtractor/tagExtractor.test.ts
@@ -1,4 +1,5 @@
 import { extractTags } from './index';
+import { cleanContentForTagExtraction } from '../../utils/regex';
 
 describe('tagExtractor', () => {
   describe('structured prefix pass', () => {
@@ -106,8 +107,32 @@ describe('tagExtractor', () => {
       expect(extractTags('gamergate horrifying')).toEqual([]);
     });
 
-    it('ignores standalone words without a prefix', () => {
-      expect(extractTags('horror game chill')).toEqual([]);
+    it('extracts standalone words that are all taxonomy terms', () => {
+      expect(extractTags('horror game chill')).toEqual([
+        'horror',
+        'game',
+        'chill'
+      ]);
+    });
+
+    it('extracts inline tags after a URL when cleaned', () => {
+      const cleaned = cleanContentForTagExtraction(
+        'https://fixupx.com/minhyn01/status/2062648087517016481 kino, chill'
+      );
+      expect(extractTags(cleaned)).toEqual(['kino', 'chill']);
+    });
+
+    it('extracts space-separated inline tags after a URL', () => {
+      const cleaned = cleanContentForTagExtraction(
+        'https://fixupx.com/minhyn01/status/2062648087517016481 kino chill'
+      );
+      expect(extractTags(cleaned)).toEqual(['kino', 'chill']);
+    });
+
+    it('still ignores inline prose with non-taxonomy words', () => {
+      expect(extractTags('A chill horror world with puzzle elements')).toEqual(
+        []
+      );
     });
   });
 
@@ -125,8 +150,71 @@ describe('tagExtractor', () => {
       expect(extractTags('Just some random text about cats')).toEqual([]);
     });
 
+    it('strips trailing ? . ! from tags in structured lines', () => {
+      expect(extractTags('Tags: chill, kino?')).toEqual(['chill', 'kino']);
+      expect(extractTags('Tags: kino. chill!')).toEqual(['kino', 'chill']);
+    });
+
     it('returns empty when prefix has no content', () => {
       expect(extractTags('Tags:')).toEqual([]);
+    });
+  });
+
+  describe('real-world message formats', () => {
+    const clean = cleanContentForTagExtraction;
+
+    it('Format 1 — URL + Tags prefix', () => {
+      const msg =
+        'https://fixupx.com/minhyn01/status/2062648087517016481\nTags: kino, chill';
+      expect(extractTags(clean(msg))).toEqual(['kino', 'chill']);
+    });
+
+    it('Format 2 — URL + inline tags (no prefix)', () => {
+      const msg =
+        'https://fixupx.com/minhyn01/status/2062648087517016481 kino chill';
+      expect(extractTags(clean(msg))).toEqual(['kino', 'chill']);
+    });
+
+    it('Format 3 — URL + Tags prefix (3 tags)', () => {
+      const msg =
+        'https://fixupx.com/Bradlee1011/status/2063087928151044100\nTags: adventure, gamerip, kino';
+      expect(extractTags(clean(msg))).toEqual(['adventure', 'gamerip', 'kino']);
+    });
+
+    it('Format 4 — direct world link + single tag', () => {
+      const msg =
+        'https://vrchat.com/home/world/wrld_261a4ff0-1a46-4a86-9bd5-ec2160f1c689 kino';
+      expect(extractTags(clean(msg))).toEqual(['kino']);
+    });
+
+    it('Format 5 — direct link + tags + description on next line', () => {
+      const msg =
+        'https://vrchat.com/home/world/wrld_f655391d-7be0-419c-9d0b-8b8c842d8d17 comfy chill\nbig mansion by the beach';
+      expect(extractTags(clean(msg))).toEqual(['comfy', 'chill']);
+    });
+
+    it('Format 6 — direct link + tags + prose (majority valid)', () => {
+      const msg =
+        'https://vrchat.com/home/world/wrld_e8d2f69c-fa79-4de3-ade6-1d7635f19c67 meme game (little) horror\ni think you have to collect some items or something goal is unclear :Shrug:';
+      expect(extractTags(clean(msg))).toEqual(['meme', 'game', 'horror']);
+    });
+
+    it('Format 7 — direct link + tech + canonicalized VRMV', () => {
+      const msg =
+        'https://vrchat.com/home/world/wrld_d8803d30-f34e-48ee-a6e6-0c4c53e20b62 tech VRMV';
+      expect(extractTags(clean(msg))).toEqual(['tech', 'particle live / vrmv']);
+    });
+
+    it('Format 8 — /info link + single tag', () => {
+      const msg =
+        'https://vrchat.com/home/world/wrld_72b49c0d-527b-4bad-b39a-b265bcb3f497/info game';
+      expect(extractTags(clean(msg))).toEqual(['game']);
+    });
+
+    it('Format 9 — direct link + 2 tags', () => {
+      const msg =
+        'https://vrchat.com/home/world/wrld_9d95e56c-c041-4e13-b030-1cde04405658 chill kino';
+      expect(extractTags(clean(msg))).toEqual(['chill', 'kino']);
     });
   });
 });


### PR DESCRIPTION
## Problem

The tag extractor only recognized structured tag lines (Tags:, Tag:, Category:, etc.).
This meant messages like:

```
https://fixupx.com/minhyn01/status/2062648087517016481 kino, chill
```

had their tags completely ignored after URL cleaning.

Additionally, `cleanContentForTagExtraction` collapsed newlines into spaces, so multi-line
messages like:

```
https://vrchat.com/... comfy chill
big mansion by the beach
```

could not separate the tag line from the description line.

Finally, the unstructured pass required 100% of tokens to be valid taxonomy terms,
so lines like `meme game (little) horror` were entirely rejected because `(little)`
is not a tag.

## Changes

- **Preserve newlines** in `cleanContentForTagExtraction` so multi-line messages keep
their line structure. Tag lines are processed separately from prose lines.
- **Add an unstructured pass** in `extractTags` that accepts any line where a majority
(≥50%) of tokens are valid taxonomy terms (after stripping punctuation). This handles
inline tags after URLs, as well as plain space-separated tag lists with occasional
non-tag descriptors like `(little)`.
- **Strip trailing `? . !`** from tokens in both structured and unstructured passes,
so `kino?` is correctly recognized as `kino`.
- **Update tests**: standalone taxonomy words are now extracted, and 9 new tests
cover all real-world message formats from the project's format spec.

## Real-world format coverage

| Format | Result |
|--------|--------|
| URL + `Tags: kino, chill` | ✅ `kino, chill` |
| URL + `kino chill` | ✅ `kino, chill` |
| Direct world link + `comfy chill` + description | ✅ `comfy, chill` |
| Direct link + `meme game (little) horror` + prose | ✅ `meme, game, horror` |
| Direct link + `tech VRMV` | ✅ `tech, particle live / vrmv` |
| `/info` link + `game` | ✅ `game` |

## Verification

- TypeScript compiles cleanly
- All 202 tests pass (9 new tests added for real-world formats)