### PR TITLE
[FIX]: stop duplicate log lines in PM2 output

### DIFF
--- a/ecosystem.config.js
+++ b/ecosystem.config.js
@@ -12,8 +12,6 @@ module.exports = {
         NODE_ENV: 'production'
       },
       log_file: '/home/world-tagger/.pm2/logs/world-tagger-man.log',
-      out_file: '/home/world-tagger/.pm2/logs/world-tagger-man.log',
-      error_file: '/home/world-tagger/.pm2/logs/world-tagger-man.log',
       log_date_format: 'YYYY-MM-DD HH:mm:ss Z',
       merge_logs: true,
       time: true

--- a/ecosystem.test.config.js
+++ b/ecosystem.test.config.js
@@ -12,8 +12,6 @@ module.exports = {
         NODE_ENV: 'production'
       },
       log_file: '/home/world-tagger/.pm2/logs/world-tagger-man-test.log',
-      out_file: '/home/world-tagger/.pm2/logs/world-tagger-man-test.log',
-      error_file: '/home/world-tagger/.pm2/logs/world-tagger-man-test.log',
       log_date_format: 'YYYY-MM-DD HH:mm:ss Z',
       merge_logs: true,
       time: true


### PR DESCRIPTION
## Problem

Bot logs were appearing twice in the PM2 log files.

## Root Cause

Both `ecosystem.config.js` and `ecosystem.test.config.js` had `log_file`, `out_file`, and `error_file` all pointing to the same path. With `merge_logs: true`, PM2 writes each stream to its dedicated file **and** to the merged log file, producing duplicate lines.

## Fix

Removed the redundant `out_file` and `error_file` entries. `log_file` with `merge_logs: true` is sufficient to capture both stdout and stderr in one place.

## Verification

- Branch: `fix/pm2-duplicate-logging`
- All 202 tests pass
