### PR TITLE
[FIX]: world embed description uses original message instead of tweet content

### DIFF
--- a/src/events/messageCreate/watchForVRCWorldLinks/worldExtraction/index.ts
+++ b/src/events/messageCreate/watchForVRCWorldLinks/worldExtraction/index.ts
@@ -47,7 +47,7 @@ export const extractAllWorldIdsFromMessage = async (
       for (const worldId of tweetWorldIds) {
         if (!seen.has(worldId)) {
           seen.add(worldId);
-          results.push({ worldId, sourceContent: tweetContent });
+          results.push({ worldId, sourceContent: content });
         }
       }
       continue;
@@ -60,7 +60,7 @@ export const extractAllWorldIdsFromMessage = async (
     );
     if (worldIdFromText && !seen.has(worldIdFromText)) {
       seen.add(worldIdFromText);
-      results.push({ worldId: worldIdFromText, sourceContent: tweetContent });
+      results.push({ worldId: worldIdFromText, sourceContent: content });
     }
   }
 


### PR DESCRIPTION
## Problem
When a user posts a message containing a Twitter/X link, the bot was replacing the embed description (the user's original message) with the fetched tweet text. This stripped any tagging, comments, or formatting the user included in their original Discord message.

## Root Cause
PR #74 introduced , which returned  for Twitter links. This  was then passed to  and used as the embed description, overwriting the user's original message content.

## Fix
In , changed  for Twitter-resolved world IDs from  to the original  (the Discord message text). The tweet text is still used internally for world ID extraction, but the embed now preserves the user's original message.

## Verification
All 120 existing tests pass.
