### PR TITLE
chore: make API host configurable for Caddy/reverse proxy support

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -12,6 +12,9 @@ LOW_CAPACITY_THRESHOLD=20
 
 # API server config
 API_PORT=3000
+# API_HOST controls which interface the Fastify API binds to.
+# Use 127.0.0.1 when running behind a reverse proxy like Caddy or Nginx.
+API_HOST=0.0.0.0
 # API_TOKEN is a Bearer token for /api/* endpoints (supports multiple tokens
 # separated by commas). Falls back to EXPORT_API_TOKEN if not set.
 API_TOKEN=

--- a/src/apiServer/index.ts
+++ b/src/apiServer/index.ts
@@ -59,12 +59,13 @@ export async function stopApiServer(): Promise<void> {
 export async function startApiServer() {
   const fastify = createApiServer();
   const port = Config.API_PORT;
+  const host = Config.API_HOST;
 
   try {
-    await fastify.listen({ port, host: '0.0.0.0' });
+    await fastify.listen({ port, host });
     apiServerInstance = fastify;
     isApiRunning = true;
-    logger.info(`🚀 API server listening on http://0.0.0.0:${port}`);
+    logger.info(`🚀 API server listening on http://${host}:${port}`);
   } catch (error) {
     logger.error('Failed to start API server:', error);
   }

--- a/src/assets/config.ts
+++ b/src/assets/config.ts
@@ -21,6 +21,7 @@ const Config = {
   LOW_CAPACITY_THRESHOLD: Number(process.env.LOW_CAPACITY_THRESHOLD) || 20,
   DATABASE_PATH: process.env.DATABASE_PATH || './worlds.db',
   API_PORT: Number(process.env.API_PORT) || 3000,
+  API_HOST: process.env.API_HOST || '0.0.0.0',
   API_TOKEN: process.env.API_TOKEN
     ? process.env.API_TOKEN.split(',')
     : process.env.EXPORT_API_TOKEN


### PR DESCRIPTION
This change exposes the API host bind address via the `API_HOST` environment variable, making it easier to run the Fastify API behind a reverse proxy like Caddy.

### Changes
- Added `API_HOST` to `.env.sample` (defaults to `0.0.0.0`).
- Updated `src/assets/config.ts` to read `API_HOST` from env.
- Updated `src/apiServer/index.ts` to use `Config.API_HOST` instead of hardcoded `0.0.0.0`.

### Why
When running Caddy on the same Ubuntu server, the Fastify API should ideally bind to `127.0.0.1` so it is not directly reachable from the internet. With `API_HOST=127.0.0.1`, Caddy can still reverse-proxy to `localhost:3000` while port 3000 stays closed externally.

### Related
- Plan: `.pi/plans/caddy-https-setup.md`