### PR TITLE
[FEAT] Add backend text search query support to /api/worlds

### DIFF
--- a/src/apiServer/apiServer.test.ts
+++ b/src/apiServer/apiServer.test.ts
@@ -264,6 +264,63 @@ describe('API Server', () => {
       );
     });
 
+    it('passes search filter to repository', async () => {
+      const getAllPaginated = jest.fn(() => ({ total: 0, rows: [] }));
+      asMock(getWorldRepository).mockReturnValue(
+        createMockRepo({ getAllPaginated })
+      );
+
+      await app.inject({
+        method: 'GET',
+        url: '/api/worlds?search=ghostly',
+        headers: { authorization: 'Bearer test-token' }
+      });
+
+      expect(getAllPaginated).toHaveBeenCalledWith(
+        50,
+        0,
+        expect.objectContaining({ search: 'ghostly' })
+      );
+    });
+
+    it('ignores empty or whitespace-only search query', async () => {
+      const getAllPaginated = jest.fn(() => ({ total: 0, rows: [] }));
+      asMock(getWorldRepository).mockReturnValue(
+        createMockRepo({ getAllPaginated })
+      );
+
+      await app.inject({
+        method: 'GET',
+        url: '/api/worlds?search=%20%20',
+        headers: { authorization: 'Bearer test-token' }
+      });
+
+      expect(getAllPaginated).toHaveBeenCalledWith(50, 0, undefined);
+    });
+
+    it('combines search, tag and quality filters', async () => {
+      const getAllPaginated = jest.fn(() => ({ total: 0, rows: [] }));
+      asMock(getWorldRepository).mockReturnValue(
+        createMockRepo({ getAllPaginated })
+      );
+
+      await app.inject({
+        method: 'GET',
+        url: '/api/worlds?search=spooky&tag=horror&quality=good',
+        headers: { authorization: 'Bearer test-token' }
+      });
+
+      expect(getAllPaginated).toHaveBeenCalledWith(
+        50,
+        0,
+        expect.objectContaining({
+          search: 'spooky',
+          tags: ['horror'],
+          quality: ['good']
+        })
+      );
+    });
+
     it('caps limit at 500', async () => {
       const getAllPaginated = jest.fn(() => ({ total: 0, rows: [] }));
       asMock(getWorldRepository).mockReturnValue(

--- a/src/apiServer/routes/worlds.ts
+++ b/src/apiServer/routes/worlds.ts
@@ -63,9 +63,17 @@ const worldsRoute: FastifyPluginAsync = async (fastify: FastifyInstance) => {
         ? [String(query.quality) as 'good' | 'bad']
         : undefined;
 
-    const filters: { tags?: string[]; quality?: ('good' | 'bad')[] } = {};
+    const filters: {
+      tags?: string[];
+      quality?: ('good' | 'bad')[];
+      search?: string;
+    } = {};
     if (tags) filters.tags = tags;
     if (quality) filters.quality = quality;
+
+    const search =
+      typeof query.search === 'string' ? query.search.trim() : undefined;
+    if (search) filters.search = search;
 
     const { rows, total } = getWorldRepository().getAllPaginated(
       limit,

--- a/src/utils/database/worldRepository.test.ts
+++ b/src/utils/database/worldRepository.test.ts
@@ -301,6 +301,192 @@ describe('WorldRepository', () => {
       expect(total).toBe(1);
     });
 
+    it('filters by search term across name, author, source content, world id and tags', () => {
+      repo.upsert(
+        createTestRecord({
+          worldId: 'wrld_match_name',
+          guildId: 'guild-1',
+          name: 'Ghost Forest',
+          authorName: 'SomeAuthor',
+          tags: ['horror']
+        })
+      );
+      repo.upsert(
+        createTestRecord({
+          worldId: 'wrld_match_author',
+          guildId: 'guild-1',
+          name: 'Mystery Mansion',
+          authorName: 'GhostlyBuilder',
+          tags: ['game']
+        })
+      );
+      repo.upsert(
+        createTestRecord({
+          worldId: 'wrld_match_tag',
+          guildId: 'guild-1',
+          name: 'Plain World',
+          authorName: 'PlainAuthor',
+          tags: ['ghost']
+        })
+      );
+      repo.upsert(
+        createTestRecord({
+          worldId: 'wrld_match_source',
+          guildId: 'guild-1',
+          name: 'Source World',
+          authorName: 'SourceAuthor',
+          tags: ['puzzle'],
+          sourceContent: 'ghostly atmosphere'
+        })
+      );
+      repo.upsert(
+        createTestRecord({
+          worldId: 'wrld_ghost_id',
+          guildId: 'guild-1',
+          name: 'Id World',
+          authorName: 'IdAuthor',
+          tags: ['rpg'],
+          sourceContent: null
+        })
+      );
+      repo.upsert(
+        createTestRecord({
+          worldId: 'wrld_no_match',
+          guildId: 'guild-1',
+          name: 'Sunny Beach',
+          authorName: 'SunDev',
+          tags: ['relax']
+        })
+      );
+
+      const { rows, total } = repo.getAllPaginated(20, 0, { search: 'ghost' });
+      expect(total).toBe(5);
+      expect(rows.map((r) => r.worldId).sort()).toEqual([
+        'wrld_ghost_id',
+        'wrld_match_author',
+        'wrld_match_name',
+        'wrld_match_source',
+        'wrld_match_tag'
+      ]);
+    });
+
+    it('requires all search terms to match (AND logic)', () => {
+      repo.upsert(
+        createTestRecord({
+          worldId: 'wrld_both_terms',
+          guildId: 'guild-1',
+          name: 'Crystal Cave',
+          authorName: 'CaveAuthor',
+          tags: ['crystal']
+        })
+      );
+      repo.upsert(
+        createTestRecord({
+          worldId: 'wrld_one_term',
+          guildId: 'guild-1',
+          name: 'Crystal Lake',
+          authorName: 'LakeAuthor',
+          tags: ['water']
+        })
+      );
+
+      const { rows, total } = repo.getAllPaginated(20, 0, {
+        search: 'crystal cave'
+      });
+      expect(total).toBe(1);
+      expect(rows[0].worldId).toBe('wrld_both_terms');
+    });
+
+    it('ignores empty or whitespace-only search', () => {
+      const { rows: empty } = repo.getAllPaginated(10, 0, { search: '' });
+      const { rows: whitespace } = repo.getAllPaginated(10, 0, {
+        search: '   '
+      });
+      const { rows: noSearch } = repo.getAllPaginated(10, 0);
+
+      expect(empty).toHaveLength(5);
+      expect(whitespace).toHaveLength(5);
+      expect(noSearch).toHaveLength(5);
+    });
+
+    it('combines search with tag and quality filters', () => {
+      repo.upsert(
+        createTestRecord({
+          worldId: 'wrld_good_match',
+          guildId: 'guild-1',
+          name: 'Ghost Ship',
+          tags: ['horror']
+        })
+      );
+      repo.updateQuality('wrld_good_match', 'guild-1', 'good');
+      repo.upsert(
+        createTestRecord({
+          worldId: 'wrld_bad_match',
+          guildId: 'guild-1',
+          name: 'Ghost Town',
+          tags: ['horror']
+        })
+      );
+      repo.updateQuality('wrld_bad_match', 'guild-1', 'bad');
+      repo.upsert(
+        createTestRecord({
+          worldId: 'wrld_good_no_match',
+          guildId: 'guild-1',
+          name: 'Sunny Ship',
+          tags: ['horror']
+        })
+      );
+      repo.updateQuality('wrld_good_no_match', 'guild-1', 'good');
+
+      const { rows, total } = repo.getAllPaginated(20, 0, {
+        search: 'ghost',
+        tags: ['horror'],
+        quality: ['good']
+      });
+      expect(total).toBe(1);
+      expect(rows[0].worldId).toBe('wrld_good_match');
+    });
+
+    it('is case-insensitive for ASCII search terms', () => {
+      repo.upsert(
+        createTestRecord({
+          worldId: 'wrld_case',
+          guildId: 'guild-1',
+          name: 'UPPERCASE WORLD'
+        })
+      );
+
+      const { rows, total } = repo.getAllPaginated(20, 0, {
+        search: 'uppercase'
+      });
+      expect(total).toBe(1);
+      expect(rows[0].worldId).toBe('wrld_case');
+    });
+
+    it('respects pagination when searching', () => {
+      for (let i = 0; i < 5; i++) {
+        repo.upsert(
+          createTestRecord({
+            worldId: `wrld_paginated_${i}`,
+            guildId: 'guild-1',
+            name: `Searchable World ${i}`
+          })
+        );
+      }
+
+      const { rows: first, total } = repo.getAllPaginated(2, 0, {
+        search: 'Searchable'
+      });
+      const { rows: second } = repo.getAllPaginated(2, 2, {
+        search: 'Searchable'
+      });
+
+      expect(total).toBe(5);
+      expect(first).toHaveLength(2);
+      expect(second).toHaveLength(2);
+      expect(first[0].worldId).not.toBe(second[0].worldId);
+    });
+
     it('combines guildId and tag filters', () => {
       repo.upsert(
         createTestRecord({

--- a/src/utils/database/worldRepository.ts
+++ b/src/utils/database/worldRepository.ts
@@ -266,6 +266,7 @@ export class WorldRepository {
       tags?: string[];
       guildId?: string;
       quality?: ('good' | 'bad')[];
+      search?: string;
     }
   ): { rows: WorldRecord[]; total: number } {
     const whereParts: string[] = [];
@@ -288,6 +289,17 @@ export class WorldRepository {
           'EXISTS (SELECT 1 FROM json_each(tags) WHERE value = ?)'
         );
         params.push(tag);
+      }
+    }
+
+    if (filters?.search) {
+      const terms = filters.search.trim().split(/\s+/).filter(Boolean);
+      for (const term of terms) {
+        const pattern = `%${term}%`;
+        whereParts.push(
+          `(name LIKE ? OR author_name LIKE ? OR source_content LIKE ? OR world_id LIKE ? OR EXISTS (SELECT 1 FROM json_each(tags) WHERE value LIKE ?))`
+        );
+        params.push(pattern, pattern, pattern, pattern, pattern);
       }
     }
 


### PR DESCRIPTION
## Description

Adds a new optional `?search=` query parameter to `GET /api/worlds` so the frontend can filter worlds server-side by text. This supports the endless-scrolling work on the `/worlds` screen by allowing search results to be paginated together with tag/quality filters.

- Search terms are split on whitespace and applied with AND logic.
- Each term matches case-insensitively against `name`, `author_name`, `source_content`, `world_id`, and individual tags.
- Empty/whitespace-only `search` values are ignored.
- Fully backwards-compatible: existing requests without `search` behave exactly as before.

## Type of change

- [x] New feature (non-breaking change that adds functionality)

## Checklist

- [x] Tests pass (`pnpm test` - 211 passed)
- [x] No new warnings introduced (`pnpm lint` - clean)
