### PR TITLE
[FEAT] Add minCapacity/maxCapacity filtering to GET /api/worlds

### DIFF
--- a/manual/API.md
+++ b/manual/API.md
@@ -73,12 +73,15 @@ Returns a paginated, filterable list of world records.
 
 **Query parameters**
 
-| Parameter | Type             | Default | Max | Description                                        |
-|-----------|------------------|---------|-----|----------------------------------------------------|
-| `limit`   | number           | `50`    | 500 | Number of records to return.                       |
-| `offset`  | number           | `0`     | —   | Number of records to skip (for pagination).        |
-| `tag`     | string / string[] | —      | —   | Filter by tag(s). Comma-separated or repeated. Multiple values use AND logic. |
-| `quality` | string / string[] | —      | —   | Filter by quality. Values: `good`, `bad`.         |
+| Parameter     | Type              | Default | Max | Description                                        |
+|---------------|-------------------|---------|-----|----------------------------------------------------|
+| `limit`       | number            | `50`    | 500 | Number of records to return.                       |
+| `offset`      | number            | `0`     | —   | Number of records to skip (for pagination).        |
+| `tag`         | string / string[] | —       | —   | Filter by tag(s). Comma-separated or repeated. Multiple values use AND logic. |
+| `quality`     | string / string[] | —       | —   | Filter by quality. Values: `good`, `bad`.         |
+| `search`      | string            | —       | —   | Search across name, author, source content, world id, and tags. |
+| `minCapacity` | integer           | —       | —   | Minimum world capacity (inclusive). Must be ≥ 1 and ≤ 80. |
+| `maxCapacity` | integer           | —       | —   | Maximum world capacity (inclusive). Must be ≥ 1 and ≤ 80. |
 
 **Response**
 
@@ -124,12 +127,30 @@ GET /api/worlds?quality=bad
 GET /api/worlds?quality=good&quality=bad
 ```
 
-**Combining filters**
+**Filtering by capacity**
 
-Tag and quality filters work together with AND logic:
+Filter worlds by maximum player capacity using an inclusive range. VRChat worlds currently support 1–80 players. Worlds with an unknown (`null`) capacity are excluded whenever a capacity filter is active.
 
 ```
-GET /api/worlds?tag=horror&quality=good
+GET /api/worlds?minCapacity=10
+GET /api/worlds?maxCapacity=40
+GET /api/worlds?minCapacity=10&maxCapacity=40
+```
+
+Validation rules:
+
+- `minCapacity` and `maxCapacity` must be integers.
+- `minCapacity` must be at least `1`.
+- `maxCapacity` must be at most `80`.
+- `minCapacity` must be less than or equal to `maxCapacity` when both are provided.
+- Invalid values result in a **400 Bad Request**.
+
+**Combining filters**
+
+Tag, quality, search, and capacity filters work together with AND logic:
+
+```
+GET /api/worlds?minCapacity=10&maxCapacity=40&quality=good&tag=horror
 ```
 
 **Pagination**
@@ -235,10 +256,11 @@ Each world object returned by the API has the following fields:
 
 ## Error Responses
 
-| Status Code | Meaning              | Body                              |
-|-------------|----------------------|-----------------------------------|
-| `401`       | Missing / invalid token | `{ "error": "Unauthorized" }`  |
-| `404`       | World not found        | `{ "error": "World not found" }` |
+| Status Code | Meaning                | Body                                           |
+|-------------|------------------------|------------------------------------------------|
+| `400`       | Invalid query params   | `{ "error": "minCapacity must be an integer" }` |
+| `401`       | Missing / invalid token | `{ "error": "Unauthorized" }`                  |
+| `404`       | World not found        | `{ "error": "World not found" }`               |
 
 ---
 
@@ -255,6 +277,10 @@ curl -H "Authorization: Bearer my-token" \
 # List worlds tagged both "horror" and "game", marked as "good"
 curl -H "Authorization: Bearer my-token" \
   "http://localhost:3000/api/worlds?tag=horror,game&quality=good"
+
+# List worlds with capacity between 10 and 40, marked as good
+curl -H "Authorization: Bearer my-token" \
+  "http://localhost:3000/api/worlds?minCapacity=10&maxCapacity=40&quality=good"
 
 # Get a specific world
 curl -H "Authorization: Bearer my-token" \

--- a/src/apiServer/apiServer.test.ts
+++ b/src/apiServer/apiServer.test.ts
@@ -350,6 +350,121 @@ describe('API Server', () => {
 
       expect(getAllPaginated).toHaveBeenCalledWith(50, 100, undefined);
     });
+
+    it('passes minCapacity filter to repository', async () => {
+      const getAllPaginated = jest.fn(() => ({ total: 0, rows: [] }));
+      asMock(getWorldRepository).mockReturnValue(
+        createMockRepo({ getAllPaginated })
+      );
+
+      await app.inject({
+        method: 'GET',
+        url: '/api/worlds?minCapacity=10',
+        headers: { authorization: 'Bearer test-token' }
+      });
+
+      expect(getAllPaginated).toHaveBeenCalledWith(
+        50,
+        0,
+        expect.objectContaining({ minCapacity: 10 })
+      );
+    });
+
+    it('passes maxCapacity filter to repository', async () => {
+      const getAllPaginated = jest.fn(() => ({ total: 0, rows: [] }));
+      asMock(getWorldRepository).mockReturnValue(
+        createMockRepo({ getAllPaginated })
+      );
+
+      await app.inject({
+        method: 'GET',
+        url: '/api/worlds?maxCapacity=40',
+        headers: { authorization: 'Bearer test-token' }
+      });
+
+      expect(getAllPaginated).toHaveBeenCalledWith(
+        50,
+        0,
+        expect.objectContaining({ maxCapacity: 40 })
+      );
+    });
+
+    it('combines capacity range with tag, quality, and search filters', async () => {
+      const getAllPaginated = jest.fn(() => ({ total: 0, rows: [] }));
+      asMock(getWorldRepository).mockReturnValue(
+        createMockRepo({ getAllPaginated })
+      );
+
+      await app.inject({
+        method: 'GET',
+        url: '/api/worlds?minCapacity=10&maxCapacity=40&quality=good&tag=horror&search=spooky',
+        headers: { authorization: 'Bearer test-token' }
+      });
+
+      expect(getAllPaginated).toHaveBeenCalledWith(
+        50,
+        0,
+        expect.objectContaining({
+          minCapacity: 10,
+          maxCapacity: 40,
+          quality: ['good'],
+          tags: ['horror'],
+          search: 'spooky'
+        })
+      );
+    });
+
+    it('returns 400 when minCapacity is greater than maxCapacity', async () => {
+      const response = await app.inject({
+        method: 'GET',
+        url: '/api/worlds?minCapacity=50&maxCapacity=20',
+        headers: { authorization: 'Bearer test-token' }
+      });
+
+      expect(response.statusCode).toBe(400);
+      expect(JSON.parse(response.body)).toEqual({
+        error: 'minCapacity must be less than or equal to maxCapacity'
+      });
+    });
+
+    it('returns 400 when minCapacity is below 1', async () => {
+      const response = await app.inject({
+        method: 'GET',
+        url: '/api/worlds?minCapacity=0',
+        headers: { authorization: 'Bearer test-token' }
+      });
+
+      expect(response.statusCode).toBe(400);
+      expect(JSON.parse(response.body)).toEqual({
+        error: 'minCapacity must be at least 1'
+      });
+    });
+
+    it('returns 400 when maxCapacity is above 80', async () => {
+      const response = await app.inject({
+        method: 'GET',
+        url: '/api/worlds?maxCapacity=81',
+        headers: { authorization: 'Bearer test-token' }
+      });
+
+      expect(response.statusCode).toBe(400);
+      expect(JSON.parse(response.body)).toEqual({
+        error: 'maxCapacity must be at most 80'
+      });
+    });
+
+    it('returns 400 for non-integer capacity values', async () => {
+      const response = await app.inject({
+        method: 'GET',
+        url: '/api/worlds?minCapacity=abc',
+        headers: { authorization: 'Bearer test-token' }
+      });
+
+      expect(response.statusCode).toBe(400);
+      expect(JSON.parse(response.body)).toEqual({
+        error: 'minCapacity must be an integer'
+      });
+    });
   });
 
   describe('GET /api/worlds/:worldId', () => {

--- a/src/apiServer/routes/worlds.ts
+++ b/src/apiServer/routes/worlds.ts
@@ -45,9 +45,30 @@ function parseTagQuery(raw: unknown): string[] | undefined {
   });
 }
 
+function parseIntegerParam(
+  raw: unknown,
+  options: { min?: number; max?: number; name: string }
+): number | undefined {
+  if (raw === undefined || raw === null || raw === '') return undefined;
+
+  const value = Number(raw);
+  if (!Number.isInteger(value)) {
+    throw new Error(`${options.name} must be an integer`);
+  }
+
+  if (options.min !== undefined && value < options.min) {
+    throw new Error(`${options.name} must be at least ${options.min}`);
+  }
+  if (options.max !== undefined && value > options.max) {
+    throw new Error(`${options.name} must be at most ${options.max}`);
+  }
+
+  return value;
+}
+
 const worldsRoute: FastifyPluginAsync = async (fastify: FastifyInstance) => {
   // GET /api/worlds
-  fastify.get('/api/worlds', async (request) => {
+  fastify.get('/api/worlds', async (request, reply) => {
     const query = request.query as Record<string, unknown>;
 
     const limit = Math.min(Number(query.limit ?? 50), 500);
@@ -63,13 +84,47 @@ const worldsRoute: FastifyPluginAsync = async (fastify: FastifyInstance) => {
         ? [String(query.quality) as 'good' | 'bad']
         : undefined;
 
+    let minCapacity: number | undefined;
+    let maxCapacity: number | undefined;
+    try {
+      minCapacity = parseIntegerParam(query.minCapacity, {
+        name: 'minCapacity',
+        min: 1,
+        max: 80
+      });
+      maxCapacity = parseIntegerParam(query.maxCapacity, {
+        name: 'maxCapacity',
+        min: 1,
+        max: 80
+      });
+    } catch (error) {
+      return reply.code(400).send({
+        error:
+          error instanceof Error ? error.message : 'Invalid capacity filter'
+      });
+    }
+
+    if (
+      minCapacity !== undefined &&
+      maxCapacity !== undefined &&
+      minCapacity > maxCapacity
+    ) {
+      return reply.code(400).send({
+        error: 'minCapacity must be less than or equal to maxCapacity'
+      });
+    }
+
     const filters: {
       tags?: string[];
       quality?: ('good' | 'bad')[];
       search?: string;
+      minCapacity?: number;
+      maxCapacity?: number;
     } = {};
     if (tags) filters.tags = tags;
     if (quality) filters.quality = quality;
+    if (minCapacity !== undefined) filters.minCapacity = minCapacity;
+    if (maxCapacity !== undefined) filters.maxCapacity = maxCapacity;
 
     const search =
       typeof query.search === 'string' ? query.search.trim() : undefined;

--- a/src/utils/database/schema.ts
+++ b/src/utils/database/schema.ts
@@ -75,6 +75,14 @@ const MIGRATIONS: Migration[] = [
         );
       }
     }
+  },
+  {
+    name: '004_add_capacity_index',
+    run: (db) => {
+      db.exec(
+        `CREATE INDEX IF NOT EXISTS idx_worlds_capacity ON world_records(capacity)`
+      );
+    }
   }
 ];
 

--- a/src/utils/database/worldRepository.test.ts
+++ b/src/utils/database/worldRepository.test.ts
@@ -505,6 +505,123 @@ describe('WorldRepository', () => {
     });
   });
 
+  describe('capacity filtering', () => {
+    beforeEach(() => {
+      repo.upsert(
+        createTestRecord({
+          worldId: 'wrld_small',
+          guildId: 'guild-1',
+          capacity: 8
+        })
+      );
+      repo.upsert(
+        createTestRecord({
+          worldId: 'wrld_medium',
+          guildId: 'guild-1',
+          capacity: 32
+        })
+      );
+      repo.upsert(
+        createTestRecord({
+          worldId: 'wrld_large',
+          guildId: 'guild-1',
+          capacity: 80
+        })
+      );
+      repo.upsert(
+        createTestRecord({
+          worldId: 'wrld_unknown',
+          guildId: 'guild-1',
+          capacity: null
+        })
+      );
+    });
+
+    it('filters by minCapacity only', () => {
+      const { rows, total } = repo.getAllPaginated(10, 0, {
+        minCapacity: 20
+      });
+      expect(total).toBe(2);
+      expect(rows.map((r) => r.worldId).sort()).toEqual([
+        'wrld_large',
+        'wrld_medium'
+      ]);
+    });
+
+    it('filters by maxCapacity only', () => {
+      const { rows, total } = repo.getAllPaginated(10, 0, {
+        maxCapacity: 20
+      });
+      expect(total).toBe(1);
+      expect(rows[0].worldId).toBe('wrld_small');
+    });
+
+    it('filters by capacity range', () => {
+      const { rows, total } = repo.getAllPaginated(10, 0, {
+        minCapacity: 10,
+        maxCapacity: 40
+      });
+      expect(total).toBe(1);
+      expect(rows[0].worldId).toBe('wrld_medium');
+    });
+
+    it('excludes records with null capacity when capacity filter is active', () => {
+      const { rows, total } = repo.getAllPaginated(10, 0, {
+        maxCapacity: 80
+      });
+      expect(total).toBe(3);
+      expect(rows.map((r) => r.worldId).sort()).toEqual([
+        'wrld_large',
+        'wrld_medium',
+        'wrld_small'
+      ]);
+    });
+
+    it('does not apply a capacity filter when neither param is provided', () => {
+      const { total } = repo.getAllPaginated(10, 0);
+      expect(total).toBe(4);
+    });
+
+    it('combines capacity filter with tag and quality filters', () => {
+      repo.upsert(
+        createTestRecord({
+          worldId: 'wrld_match',
+          guildId: 'guild-1',
+          capacity: 32,
+          tags: ['horror']
+        })
+      );
+      repo.updateQuality('wrld_match', 'guild-1', 'good');
+      repo.upsert(
+        createTestRecord({
+          worldId: 'wrld_wrong_quality',
+          guildId: 'guild-1',
+          capacity: 32,
+          tags: ['horror']
+        })
+      );
+      repo.updateQuality('wrld_wrong_quality', 'guild-1', 'bad');
+      repo.upsert(
+        createTestRecord({
+          worldId: 'wrld_wrong_capacity',
+          guildId: 'guild-1',
+          capacity: 4,
+          tags: ['horror']
+        })
+      );
+      repo.updateQuality('wrld_wrong_capacity', 'guild-1', 'good');
+
+      const { rows, total } = repo.getAllPaginated(10, 0, {
+        minCapacity: 10,
+        maxCapacity: 40,
+        tags: ['horror'],
+        quality: ['good']
+      });
+      expect(total).toBe(1);
+      expect(rows[0].worldId).toBe('wrld_match');
+    });
+  });
+
   describe('getUniqueTags', () => {
     it('returns empty array when no records', () => {
       expect(repo.getUniqueTags()).toEqual([]);

--- a/src/utils/database/worldRepository.ts
+++ b/src/utils/database/worldRepository.ts
@@ -267,6 +267,8 @@ export class WorldRepository {
       guildId?: string;
       quality?: ('good' | 'bad')[];
       search?: string;
+      minCapacity?: number;
+      maxCapacity?: number;
     }
   ): { rows: WorldRecord[]; total: number } {
     const whereParts: string[] = [];
@@ -301,6 +303,23 @@ export class WorldRepository {
         );
         params.push(pattern, pattern, pattern, pattern, pattern);
       }
+    }
+
+    if (
+      filters?.minCapacity !== undefined ||
+      filters?.maxCapacity !== undefined
+    ) {
+      whereParts.push('capacity IS NOT NULL');
+    }
+
+    if (filters?.minCapacity !== undefined) {
+      whereParts.push('capacity >= ?');
+      params.push(filters.minCapacity);
+    }
+
+    if (filters?.maxCapacity !== undefined) {
+      whereParts.push('capacity <= ?');
+      params.push(filters.maxCapacity);
     }
 
     const whereClause =


### PR DESCRIPTION
## Issue
Closes #[FEAT] Add filtering by max player count (capacity range) on /worlds

## Description
Adds backend support for filtering worlds by player capacity on the existing `GET /api/worlds` endpoint.

- Parses and validates optional `minCapacity` and `maxCapacity` query parameters (integers, 1–80 range).
- Returns **400 Bad Request** for invalid, out-of-range, or inverted (`minCapacity > maxCapacity`) values.
- Extends `WorldRepository.getAllPaginated` to apply the capacity range using AND logic alongside existing `tag`, `quality`, `search`, and `guildId` filters.
- Excludes records with a null `capacity` whenever a capacity filter is active.
- Adds a new database migration (`004_add_capacity_index`) creating `idx_worlds_capacity` to keep range queries fast as the table grows.
- Adds route-level and repository-level tests covering valid filters, combinations, and validation errors.
- Updates `manual/API.md` with the new parameters, validation rules, and examples.

## Type of change
- [x] New feature (non-breaking change that adds functionality)

## Checklist
- [x] Tests pass (`pnpm test`)
- [x] No new warnings introduced (`pnpm lint`)
- [x] TypeScript compiles (`npx tsc --noEmit`)