### PR TITLE
feat: track internal_add_date from Discord message timestamp

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # custom ignores
 dist
+.worktrees
 
 # Created by https://www.gitignore.io/api/node,macos
 

--- a/docs/v2-migration-guide.md
+++ b/docs/v2-migration-guide.md
@@ -51,6 +51,7 @@ npx jiti scripts/migrate-v1-to-v2.ts
 **What it does:**
 - Fetches VRChat API data for each world (200ms delay between calls)
 - Inserts/upserts rows into `worlds.db`
+- Sets `internal_add_date` on each row from the original Discord message ID timestamp
 - Prints per-world progress with world name and author
 - On full success, renames `db.json → db.json.v1-migrated`
 
@@ -78,6 +79,7 @@ Not found (404):  6
 **Notes:**
 - Worlds deleted or made private will show "⚠️ not found or inaccessible" — this is expected
 - The script is **idempotent** — re-running it just overwrites existing rows
+- `internal_add_date` is derived from each saved Discord message ID, so re-running will not overwrite an already-populated date
 - `db.json` is **copied** (not renamed) to `db.json.v1-migrated` so your active config stays intact
 - **Do not delete `db.json`** — it still holds all channel/watch/react configuration
 
@@ -104,6 +106,7 @@ For each watched channel that contains original world posts (with tweet text / t
 - Resolves Twitter links to fetch tweet content
 - Runs the tag extractor on the source text
 - Updates `tags` and `source_content` in SQLite
+- Backfills `internal_add_date` for existing worlds from each message's timestamp
 
 **Progress updates every 25 messages:**
 ```
@@ -116,7 +119,8 @@ For each watched channel that contains original world posts (with tweet text / t
 
 **Notes:**
 - "Not Found" means the world isn't in the database (e.g., posted after migration or deleted) — this is safe to ignore
-- Re-running is safe — it just re-extracts and overwrites
+- Re-running is safe — it just re-extracts and overwrites tags/source content
+- Any worlds that were migrated without an `internal_add_date` will have it filled from the original message timestamp
 - Channels must **not** be watched to run `--tags` mode (restriction removed for backfill)
 
 ---
@@ -151,6 +155,7 @@ For your **bad** channel:
   - Bot embed URLs/descriptions
   - **Discord native forwarded message snapshots** (the `messageSnapshots` API)
 - Calls `repo.updateQuality()` for each found world
+- Backfills `internal_add_date` for existing worlds from each message's timestamp
 
 **Progress updates:**
 ```
@@ -165,6 +170,7 @@ For your **bad** channel:
 - Only the **first** world ID per message is counted
 - Worlds not in the database are skipped with a logged warning
 - Re-running is idempotent — same quality will be re-applied
+- Existing worlds will have `internal_add_date` backfilled from the message timestamp
 
 ---
 
@@ -179,8 +185,10 @@ sqlite3 worlds.db "SELECT COUNT(*) FROM world_records;"
 ### 4.2 Check a sample row
 
 ```bash
-sqlite3 worlds.db "SELECT world_id, name, author_name, tags, quality FROM world_records LIMIT 5;"
+sqlite3 worlds.db "SELECT world_id, name, author_name, tags, quality, internal_add_date FROM world_records LIMIT 5;"
 ```
+
+`internal_add_date` should be a Unix timestamp matching when the world was originally posted on Discord.
 
 ### 4.3 Check tag distribution
 
@@ -298,6 +306,7 @@ Make sure the world IDs in the channel are already in `worlds.db`. If a world wa
 - [ ] Run `npx jiti scripts/migrate-v1-to-v2.ts --dry-run`
 - [ ] Run `npx jiti scripts/migrate-v1-to-v2.ts`
 - [ ] Verify `worlds.db` has expected row count
+- [ ] Verify `internal_add_date` is populated for migrated worlds
 - [ ] Run `.crawlHistory #channel --tags` for each watched channel with original posts
 - [ ] Run `.crawlHistory #good-channel --quality good`
 - [ ] Run `.crawlHistory #bad-channel --quality bad`

--- a/scripts/migrate-v1-to-v2.ts
+++ b/scripts/migrate-v1-to-v2.ts
@@ -8,7 +8,10 @@ import { getDatabase } from '../src/utils/database';
 import { WorldRepository } from '../src/utils/database/worldRepository';
 import { runMigrations } from '../src/utils/database/schema';
 import { fetchWorldData } from '../src/events/messageCreate/watchForVRCWorldLinks/worldData';
-import { getSupportedPlatforms } from '../src/utils/helpers';
+import {
+  getSupportedPlatforms,
+  getDiscordMessageTimestampSeconds
+} from '../src/utils/helpers';
 import logger from '../src/utils/logger';
 
 const safeJsonStringify = (value: unknown): string =>
@@ -114,6 +117,7 @@ async function main(): Promise<void> {
     }
 
     try {
+      const internalAddDate = getDiscordMessageTimestampSeconds(messageId);
       const worldData = await fetchWorldData(worldId);
 
       if (!worldData || !worldData.id) {
@@ -126,6 +130,7 @@ async function main(): Promise<void> {
         worldId,
         guildId,
         messageId,
+        internalAddDate,
         name: worldData.name ?? null,
         authorName: worldData.authorName ?? null,
         capacity: worldData.capacity ?? null,

--- a/src/apiServer/routes/worlds.ts
+++ b/src/apiServer/routes/worlds.ts
@@ -22,7 +22,8 @@ function sanitizeRecord(raw: WorldRecord) {
     imageUrl: raw.imageUrl,
     vrchatUrl: buildWorldUrl(raw.worldId),
     quality: raw.quality ?? null,
-    createdAt: toDateString(raw.createdAt)
+    createdAt: toDateString(raw.createdAt),
+    internalAddDate: toDateString(raw.internalAddDate ?? undefined)
   };
 }
 

--- a/src/events/messageCreate/crawlHistory.ts
+++ b/src/events/messageCreate/crawlHistory.ts
@@ -9,9 +9,8 @@ import {
   extractAllWorldIdsFromMessage,
   extractWorldIdFromMessage
 } from './watchForVRCWorldLinks/worldExtraction';
-import { buildTagSource } from './watchForVRCWorldLinks';
+import { buildTagSource, processWorldId } from './watchForVRCWorldLinks';
 import { extractWorldId } from '../../utils/regex';
-import { checkAndHandleDuplicate } from './watchForVRCWorldLinks/duplicateHandler';
 import { emojiMap } from '../../assets/media';
 import { getWorldRepository } from '../../utils/database/worldRepository';
 import { extractTags } from '../../utils/tagExtractor';
@@ -32,6 +31,16 @@ interface ParsedCrawlCommand {
 
 // Helper function to delay execution
 const delay = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+/**
+ * Convert a Discord message's created timestamp to Unix seconds.
+ * This is the value stored in internal_add_date.
+ */
+const getMessageInternalAddDate = (msg: Message): number => {
+  return typeof msg.createdTimestamp === 'number'
+    ? Math.floor(msg.createdTimestamp / 1000)
+    : Math.floor(Date.now() / 1000);
+};
 
 /**
  * Parse .crawlHistory command into mode and options.
@@ -475,7 +484,12 @@ const crawlMessages = async (
 
         // ── DISCOVER MODE ──
         if (mode === 'discover') {
-          await handleDiscoverMode(msg, processedWorldsCache, crawlStatus);
+          await handleDiscoverMode(
+            msg,
+            processedWorldsCache,
+            crawlStatus,
+            repo
+          );
         }
 
         // ── TAGS MODE ──
@@ -579,17 +593,27 @@ const crawlMessages = async (
 
 /**
  * Handle a single message in discover mode.
+ * New worlds are fetched and inserted silently; existing worlds have their
+ * internal_add_date backfilled from the original Discord message timestamp.
  */
 async function handleDiscoverMode(
   msg: Message,
   processedWorldsCache: Set<string>,
-  crawlStatus: CrawlStatus
+  crawlStatus: CrawlStatus,
+  repo: ReturnType<typeof getWorldRepository>
 ): Promise<void> {
+  const internalAddDate = getMessageInternalAddDate(msg);
+
   // Quick cache check
   const potentialWorldId = extractWorldId(msg.content);
   if (potentialWorldId) {
     const cacheKey = `${potentialWorldId}-${msg.guildId}`;
     if (processedWorldsCache.has(cacheKey)) {
+      repo.backfillInternalAddDate(
+        potentialWorldId,
+        msg.guildId!,
+        internalAddDate
+      );
       logger.debug(
         `Skipping message ${msg.id}: world ${potentialWorldId} already processed (cache hit)`
       );
@@ -605,17 +629,33 @@ async function handleDiscoverMode(
     return;
   }
 
-  // Use the existing duplicate detection system in silent mode
-  const isDuplicate = await checkAndHandleDuplicate(msg, worldId, true);
+  const cacheKey = `${worldId}-${msg.guildId}`;
 
-  if (!isDuplicate) {
-    crawlStatus.worldsDiscovered = crawlStatus.worldsDiscovered + 1;
-    logger.info(`World found in message ${msg.id}: ${worldId} (NEW)`);
-
-    const cacheKey = `${worldId}-${msg.guildId}`;
+  // Existing world: backfill internal_add_date and move on
+  if (repo.getByWorldAndGuild(worldId, msg.guildId!)) {
+    repo.backfillInternalAddDate(worldId, msg.guildId!, internalAddDate);
     processedWorldsCache.add(cacheKey);
-  } else {
     logger.info(`World found in message ${msg.id}: ${worldId} (DUPLICATE)`);
+    await delay(RATE_LIMIT_DELAY);
+    return;
+  }
+
+  // New world: silently fetch and persist it so it has the correct timestamp
+  try {
+    await processWorldId(msg, worldId, msg.content, {
+      skipDuplicateCheck: true,
+      silent: true,
+      internalAddDate
+    });
+
+    crawlStatus.worldsDiscovered = crawlStatus.worldsDiscovered + 1;
+    processedWorldsCache.add(cacheKey);
+    logger.info(`World found in message ${msg.id}: ${worldId} (NEW)`);
+  } catch (error) {
+    logger.warn(
+      `Could not persist discovered world ${worldId} from message ${msg.id}:`,
+      error
+    );
   }
 
   await delay(RATE_LIMIT_DELAY);
@@ -655,6 +695,7 @@ async function handleTagsMode(
   );
   const tags = extractTags(tagSource);
 
+  const internalAddDate = getMessageInternalAddDate(msg);
   let updated = 0;
   let notFound = 0;
 
@@ -675,6 +716,8 @@ async function handleTagsMode(
       tags,
       sourceContent
     );
+
+    repo.backfillInternalAddDate(worldId, msg.guildId!, internalAddDate);
 
     if (didUpdate) {
       logger.info(
@@ -716,6 +759,8 @@ async function handleQualityMode(
   }
 
   const didUpdate = repo.updateQuality(worldId, msg.guildId!, qualityValue);
+  const internalAddDate = getMessageInternalAddDate(msg);
+  repo.backfillInternalAddDate(worldId, msg.guildId!, internalAddDate);
 
   if (didUpdate) {
     logger.info(

--- a/src/events/messageCreate/watchForVRCWorldLinks/index.ts
+++ b/src/events/messageCreate/watchForVRCWorldLinks/index.ts
@@ -204,16 +204,22 @@ export function buildTagSource(
 /**
  * Processes a world ID: fetches data, extracts tags, upserts to repository,
  * creates embed, sends the bot reply, then forwards it.
+ *
+ * When `silent` is true, no embeds/replies/forwards are sent. This is used by
+ * crawlHistory to backfill worlds from channel history without spamming chat.
  */
-const processWorldId = async (
+export const processWorldId = async (
   message: Message,
   worldId: string,
   sourceContent: string,
   options?: {
     skipDuplicateCheck?: boolean;
+    silent?: boolean;
+    internalAddDate?: number;
   }
 ): Promise<void> => {
   const skipDuplicateCheck = options?.skipDuplicateCheck ?? false;
+  const silent = options?.silent ?? false;
 
   if (!skipDuplicateCheck && !Config.DEV_MODE) {
     const isDuplicate = await checkAndHandleDuplicate(message, worldId);
@@ -224,10 +230,14 @@ const processWorldId = async (
 
   const worldData = await fetchWorldData(worldId);
   const supportedPlatforms = getSupportedPlatforms(worldData.unityPackages);
-  const packageSizes = await calculatePackageSizes(worldData);
 
   const tagSource = buildTagSource(message, [sourceContent]);
   const tags = extractTags(tagSource);
+
+  const messageTimestamp =
+    typeof message.createdTimestamp === 'number'
+      ? Math.floor(message.createdTimestamp / 1000)
+      : Math.floor(Date.now() / 1000);
 
   const record: WorldRecord = {
     worldId,
@@ -240,13 +250,21 @@ const processWorldId = async (
     tags,
     imageUrl: worldData.imageUrl,
     sourceContent,
-    vrchatData: safeJsonStringify(worldData)
+    vrchatData: safeJsonStringify(worldData),
+    internalAddDate: options?.internalAddDate ?? messageTimestamp
   };
 
   getWorldRepository().upsert(record);
   logger.info(
     `Saved world ${worldId} to repository with tags: ${tags.join(', ') || 'none'}`
   );
+
+  if (silent) {
+    logger.info(`Silent processing complete for ${worldId}`);
+    return;
+  }
+
+  const packageSizes = await calculatePackageSizes(worldData);
 
   const embed = createWorldEmbed(
     worldData,

--- a/src/utils/database/schema.ts
+++ b/src/utils/database/schema.ts
@@ -83,6 +83,29 @@ const MIGRATIONS: Migration[] = [
         `CREATE INDEX IF NOT EXISTS idx_worlds_capacity ON world_records(capacity)`
       );
     }
+  },
+  {
+    name: '005_add_internal_add_date_column',
+    run: (db) => {
+      const needsColumn = (table: string) => {
+        const columns = db
+          .prepare(`PRAGMA table_info(${table})`)
+          .all() as Array<{ name: string }>;
+        return !columns.some((c) => c.name === 'internal_add_date');
+      };
+
+      if (needsColumn('world_records')) {
+        db.exec(
+          `ALTER TABLE world_records ADD COLUMN internal_add_date INTEGER`
+        );
+      }
+
+      if (needsColumn('deleted_world_records')) {
+        db.exec(
+          `ALTER TABLE deleted_world_records ADD COLUMN internal_add_date INTEGER`
+        );
+      }
+    }
   }
 ];
 

--- a/src/utils/database/worldRepository.test.ts
+++ b/src/utils/database/worldRepository.test.ts
@@ -19,6 +19,7 @@ function createTestRecord(overrides: Partial<WorldRecord> = {}): WorldRecord {
     imageUrl: 'https://example.com/image.png',
     sourceContent: 'A horror game world #horror #game',
     vrchatData: '{"id":"wrld_test"}',
+    internalAddDate: 1_700_000_000,
     ...overrides
   };
 }
@@ -50,24 +51,30 @@ describe('WorldRepository', () => {
       expect(found!.tags).toEqual(['horror', 'game']);
       expect(found!.platforms).toEqual(['standalonewindows', 'android']);
       expect(found!.createdAt).toBeDefined();
+      expect(found!.internalAddDate).toBe(1_700_000_000);
     });
 
-    it('updates an existing record without resetting created_at', () => {
+    it('updates an existing record without resetting created_at or internal_add_date', () => {
       const record = createTestRecord();
       repo.upsert(record);
 
       const first = repo.getByWorldAndGuild(record.worldId, record.guildId)!;
       const originalCreatedAt = first.createdAt;
+      const originalInternalAddDate = first.internalAddDate;
       const originalId = first.id;
 
       // Small delay to ensure updated_at changes
-      const updated = createTestRecord({ name: 'Updated World' });
+      const updated = createTestRecord({
+        name: 'Updated World',
+        internalAddDate: 1_800_000_000
+      });
       repo.upsert(updated);
 
       const second = repo.getByWorldAndGuild(record.worldId, record.guildId)!;
       expect(second.id).toBe(originalId);
       expect(second.name).toBe('Updated World');
       expect(second.createdAt).toBe(originalCreatedAt);
+      expect(second.internalAddDate).toBe(originalInternalAddDate);
       expect(second.messageId).toBe(record.messageId); // original message_id preserved
       expect(second.updatedAt).toBeGreaterThanOrEqual(originalCreatedAt!);
     });
@@ -83,6 +90,93 @@ describe('WorldRepository', () => {
       expect(all).toHaveLength(2);
       expect(all.map((r) => r.guildId)).toContain('guild-a');
       expect(all.map((r) => r.guildId)).toContain('guild-b');
+    });
+
+    it('fills internal_add_date on conflict when the existing value is null', () => {
+      // Simulate a legacy row that has no internal_add_date
+      db.prepare(
+        `INSERT INTO world_records
+          (world_id, guild_id, message_id, name, author_name, capacity,
+           platforms, tags, image_url, source_content, vrchat_data, created_at, updated_at, internal_add_date)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+      ).run(
+        createTestRecord().worldId,
+        createTestRecord().guildId,
+        createTestRecord().messageId,
+        createTestRecord().name,
+        createTestRecord().authorName,
+        createTestRecord().capacity,
+        JSON.stringify(createTestRecord().platforms),
+        JSON.stringify(createTestRecord().tags),
+        createTestRecord().imageUrl,
+        createTestRecord().sourceContent,
+        createTestRecord().vrchatData,
+        1_600_000_000,
+        1_600_000_000,
+        null
+      );
+
+      repo.upsert(createTestRecord({ internalAddDate: 1_800_000_000 }));
+      let found = repo.getByWorldAndGuild(
+        createTestRecord().worldId,
+        createTestRecord().guildId
+      )!;
+      expect(found.internalAddDate).toBe(1_800_000_000);
+
+      // Re-upserting with a different date must not overwrite
+      repo.upsert(createTestRecord({ internalAddDate: 1_900_000_000 }));
+      found = repo.getByWorldAndGuild(
+        createTestRecord().worldId,
+        createTestRecord().guildId
+      )!;
+      expect(found.internalAddDate).toBe(1_800_000_000);
+    });
+
+    it('uses provided internal_add_date on insert', () => {
+      repo.upsert(createTestRecord({ internalAddDate: 1_680_000_000 }));
+      const found = repo.getByWorldAndGuild(
+        createTestRecord().worldId,
+        createTestRecord().guildId
+      )!;
+      expect(found.internalAddDate).toBe(1_680_000_000);
+    });
+  });
+
+  describe('backfillInternalAddDate', () => {
+    it('returns false when record does not exist', () => {
+      expect(
+        repo.backfillInternalAddDate('missing', 'missing', 1_700_000_000)
+      ).toBe(false);
+    });
+
+    it('sets internal_add_date when null and preserves existing value', () => {
+      repo.upsert(createTestRecord({ internalAddDate: undefined }));
+      db.prepare(
+        'UPDATE world_records SET internal_add_date = NULL WHERE world_id = ? AND guild_id = ?'
+      ).run(createTestRecord().worldId, createTestRecord().guildId);
+
+      expect(
+        repo.backfillInternalAddDate(
+          createTestRecord().worldId,
+          createTestRecord().guildId,
+          1_650_000_000
+        )
+      ).toBe(true);
+
+      const found = repo.getByWorldAndGuild(
+        createTestRecord().worldId,
+        createTestRecord().guildId
+      )!;
+      expect(found.internalAddDate).toBe(1_650_000_000);
+
+      expect(
+        repo.backfillInternalAddDate(
+          createTestRecord().worldId,
+          createTestRecord().guildId,
+          1_800_000_000
+        )
+      ).toBe(false);
+      expect(found.internalAddDate).toBe(1_650_000_000);
     });
   });
 
@@ -137,6 +231,23 @@ describe('WorldRepository', () => {
       const remaining = repo.getByWorldId(createTestRecord().worldId);
       expect(remaining).toHaveLength(1);
       expect(remaining[0].guildId).toBe('guild-b');
+    });
+
+    it('archives internal_add_date into deleted_world_records', () => {
+      repo.upsert(
+        createTestRecord({ guildId: 'guild-a', internalAddDate: 1_700_000_000 })
+      );
+
+      repo.deleteByWorldAndGuild(createTestRecord().worldId, 'guild-a');
+
+      const archived = db
+        .prepare(
+          'SELECT internal_add_date FROM deleted_world_records WHERE world_id = ? AND guild_id = ?'
+        )
+        .get(createTestRecord().worldId, 'guild-a') as {
+        internal_add_date: number;
+      };
+      expect(archived.internal_add_date).toBe(1_700_000_000);
     });
   });
 

--- a/src/utils/database/worldRepository.ts
+++ b/src/utils/database/worldRepository.ts
@@ -18,6 +18,7 @@ export interface WorldRecord {
   quality?: 'good' | 'bad' | null;
   createdAt?: number;
   updatedAt?: number;
+  internalAddDate?: number | null;
 }
 
 function rowToRecord(row: Record<string, unknown>): WorldRecord {
@@ -36,7 +37,8 @@ function rowToRecord(row: Record<string, unknown>): WorldRecord {
     vrchatData: row.vrchat_data as string | null,
     quality: (row.quality as 'good' | 'bad' | null) ?? null,
     createdAt: row.created_at as number,
-    updatedAt: row.updated_at as number
+    updatedAt: row.updated_at as number,
+    internalAddDate: (row.internal_add_date as number | null) ?? null
   };
 }
 
@@ -57,16 +59,18 @@ export class WorldRepository {
   }
 
   /**
-   * Upsert a world record. Preserves created_at and id on update;
-   * updates all other fields and sets updated_at to now.
+   * Upsert a world record. Preserves created_at, id, and internal_add_date on
+   * update; updates all other fields and sets updated_at to now. When
+   * internal_add_date is missing on both insert and the existing row, the
+   * current time is used as a fallback.
    */
   upsert(record: WorldRecord): void {
     const sql = `
       INSERT INTO world_records
         (world_id, guild_id, message_id, name, author_name, capacity,
-         platforms, tags, image_url, source_content, vrchat_data, created_at, updated_at)
+         platforms, tags, image_url, source_content, vrchat_data, created_at, updated_at, internal_add_date)
       VALUES
-        (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, COALESCE(?, strftime('%s','now')), strftime('%s','now'))
+        (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, COALESCE(?, strftime('%s','now')), strftime('%s','now'), COALESCE(?, strftime('%s','now')))
       ON CONFLICT(world_id, guild_id) DO UPDATE SET
         name = excluded.name,
         author_name = excluded.author_name,
@@ -76,7 +80,8 @@ export class WorldRepository {
         image_url = excluded.image_url,
         source_content = excluded.source_content,
         vrchat_data = excluded.vrchat_data,
-        updated_at = excluded.updated_at
+        updated_at = excluded.updated_at,
+        internal_add_date = COALESCE(world_records.internal_add_date, excluded.internal_add_date)
     `;
 
     const stmt = this.db.prepare(sql);
@@ -92,12 +97,44 @@ export class WorldRepository {
       record.imageUrl,
       record.sourceContent,
       record.vrchatData,
-      record.createdAt ?? null
+      record.createdAt ?? null,
+      record.internalAddDate ?? null
     );
 
     logger.debug(
       `Upserted world record ${record.worldId} in guild ${record.guildId}`
     );
+  }
+
+  /**
+   * Set internal_add_date on an existing record only when it is currently null.
+   * Used by crawlHistory and the v1 -> v2 migration to backfill the original
+   * Discord message timestamp without overwriting an already-known value.
+   */
+  backfillInternalAddDate(
+    worldId: string,
+    guildId: string,
+    internalAddDate: number
+  ): boolean {
+    const existing = this.getByWorldAndGuild(worldId, guildId);
+    if (!existing || existing.internalAddDate != null) {
+      return false;
+    }
+
+    const sql = `
+      UPDATE world_records
+      SET internal_add_date = ?
+      WHERE world_id = ? AND guild_id = ?
+    `;
+    const stmt = this.db.prepare(sql);
+    const result = stmt.run(internalAddDate, worldId, guildId);
+    const didUpdate = result.changes > 0;
+    if (didUpdate) {
+      logger.info(
+        `Backfilled internal_add_date for world ${worldId} in guild ${guildId}: ${internalAddDate}`
+      );
+    }
+    return didUpdate;
   }
 
   /**
@@ -134,8 +171,8 @@ export class WorldRepository {
   deleteByWorldAndGuild(worldId: string, guildId: string): boolean {
     const archiveSql = `
       INSERT INTO deleted_world_records
-        (world_id, guild_id, message_id, name, author_name, capacity, platforms, tags, image_url, source_content, vrchat_data, created_at, updated_at)
-      SELECT world_id, guild_id, message_id, name, author_name, capacity, platforms, tags, image_url, source_content, vrchat_data, created_at, updated_at
+        (world_id, guild_id, message_id, name, author_name, capacity, platforms, tags, image_url, source_content, vrchat_data, created_at, updated_at, internal_add_date)
+      SELECT world_id, guild_id, message_id, name, author_name, capacity, platforms, tags, image_url, source_content, vrchat_data, created_at, updated_at, internal_add_date
       FROM world_records
       WHERE world_id = ? AND guild_id = ?
     `;

--- a/src/utils/helpers/helpers.test.ts
+++ b/src/utils/helpers/helpers.test.ts
@@ -21,7 +21,8 @@ import {
   getMostRecentUnityPackageForPlatform,
   getRecentFileVersion,
   bytesToMegabytes,
-  getFileSizeForPlatform
+  getFileSizeForPlatform,
+  getDiscordMessageTimestampSeconds
 } from './index';
 
 import { vrchat } from '../externalApi/vrchat';
@@ -166,6 +167,22 @@ describe('utils/helpers', () => {
         path: { fileId: 'file_abcd-1234' }
       });
       expect(sizeMb).toBe(10);
+    });
+  });
+
+  describe('getDiscordMessageTimestampSeconds', () => {
+    it('derives a Unix timestamp from a Discord snowflake', () => {
+      const timestamp = getDiscordMessageTimestampSeconds(
+        '1234567890123456789'
+      );
+      expect(timestamp).toBeGreaterThan(1_600_000_000);
+      expect(Number.isFinite(timestamp)).toBe(true);
+    });
+
+    it('throws on invalid snowflakes', () => {
+      expect(() =>
+        getDiscordMessageTimestampSeconds('not-a-snowflake')
+      ).toThrow();
     });
   });
 });

--- a/src/utils/helpers/index.ts
+++ b/src/utils/helpers/index.ts
@@ -60,6 +60,19 @@ export const bytesToMegabytes = (bytes: number) => {
   return bytes / 1048576; // 1 MB = 1048576 bytes
 };
 
+const DISCORD_EPOCH_MS = 1420070400000;
+
+/**
+ * Derive the Unix timestamp (in seconds) from a Discord message/snowflake ID.
+ * This is used to recover the original message timestamp when only the ID
+ * is available (e.g., the v1 -> v2 migration data).
+ */
+export function getDiscordMessageTimestampSeconds(messageId: string): number {
+  const snowflake = BigInt(messageId);
+  const timestampMs = Number(snowflake >> BigInt(22)) + DISCORD_EPOCH_MS;
+  return Math.floor(timestampMs / 1000);
+}
+
 export const getFileSizeForPlatform = async (data: World, platform: string) => {
   const recentPackageForPlatform = getMostRecentUnityPackageForPlatform(
     data,


### PR DESCRIPTION
## Summary

Introduces an `internal_add_date` column that records when a world was actually added to the database, derived from the original Discord message timestamp (instead of relying on the SQLite `created_at` default).

## Changes

- Added migration `005_add_internal_add_date_column` for both `world_records` and `deleted_world_records`.
- Normal world processing now stores `internalAddDate` from `message.createdTimestamp`.
- `crawlHistory` now:
  - Persists newly discovered worlds silently with the original message timestamp.
  - Backfills `internal_add_date` for existing worlds in discover/tags/quality modes.
- V1→V2 migration script derives `internal_add_date` from each saved Discord message ID (snowflake).
- API `GET /api/worlds` responses now include `internalAddDate`.
- Updated `docs/v2-migration-guide.md` with backfill instructions.

## Verification

- `pnpm test` — 231/231 tests passing
- `pnpm lint` — clean
- `pnpm exec tsc --noEmit` — no errors

## Migration Notes

Users running the v1→v2 migration will automatically get `internal_add_date` populated. Users who have already migrated can backfill by running `.crawlHistory #channel --tags` and `.crawlHistory #channel --quality good|bad` on the relevant channels.