### PR TITLE
[FEAT] Add platform filtering to GET /api/worlds

### DIFF
--- a/manual/API.md
+++ b/manual/API.md
@@ -78,6 +78,7 @@ Returns a paginated, filterable list of world records.
 | `limit`       | number            | `50`    | 500 | Number of records to return.                       |
 | `offset`      | number            | `0`     | —   | Number of records to skip (for pagination).        |
 | `tag`         | string / string[] | —       | —   | Filter by tag(s). Comma-separated or repeated. Multiple values use AND logic. |
+| `platform`    | string / string[] | —       | —   | Filter by supported platform(s). Comma-separated or repeated. Multiple values use AND logic. |
 | `quality`     | string / string[] | —       | —   | Filter by quality. Values: `good`, `bad`.         |
 | `search`      | string            | —       | —   | Search across name, author, source content, world id, and tags. |
 | `minCapacity` | integer           | —       | —   | Minimum world capacity (inclusive). Must be ≥ 1 and ≤ 80. |
@@ -117,6 +118,17 @@ GET /api/worlds?tag=horror,game
 GET /api/worlds?tag=horror&tag=game
 ```
 
+**Filtering by platforms**
+
+To filter worlds that support **all** specified platforms, use comma-separated
+values or repeat the `platform` parameter:
+
+```
+GET /api/worlds?platform=standalonewindows,android
+GET /api/worlds?platform=standalonewindows&platform=android
+GET /api/worlds?platform=standalonewindows&platform=android&platform=ios
+```
+
 **Filtering by quality**
 
 To filter worlds by manual quality rating:
@@ -147,10 +159,10 @@ Validation rules:
 
 **Combining filters**
 
-Tag, quality, search, and capacity filters work together with AND logic:
+Tag, platform, quality, search, and capacity filters work together with AND logic:
 
 ```
-GET /api/worlds?minCapacity=10&maxCapacity=40&quality=good&tag=horror
+GET /api/worlds?minCapacity=10&maxCapacity=40&quality=good&tag=horror&platform=android
 ```
 
 **Pagination**
@@ -296,7 +308,7 @@ curl -H "Authorization: Bearer my-token" \
 ## Notes
 
 - The API is **read-only**. There are no endpoints to create, update, or delete records.
-- Filtering by multiple tags uses **AND** logic: only worlds with *all* specified tags
+- Filtering by multiple tags or platforms uses **AND** logic: only worlds with *all* specified values
   are returned.
 - The `quality` field is set via Discord reactions (`👍` / `👎`) and reflects a
   manual rating applied to the world record.

--- a/src/apiServer/apiServer.test.ts
+++ b/src/apiServer/apiServer.test.ts
@@ -226,6 +226,63 @@ describe('API Server', () => {
       );
     });
 
+    it('passes platform filters to repository', async () => {
+      const getAllPaginated = jest.fn(() => ({ total: 0, rows: [] }));
+      asMock(getWorldRepository).mockReturnValue(
+        createMockRepo({ getAllPaginated })
+      );
+
+      await app.inject({
+        method: 'GET',
+        url: '/api/worlds?platform=standalonewindows',
+        headers: { authorization: 'Bearer test-token' }
+      });
+
+      expect(getAllPaginated).toHaveBeenCalledWith(
+        50,
+        0,
+        expect.objectContaining({ platforms: ['standalonewindows'] })
+      );
+    });
+
+    it('accepts comma-separated platforms via ?platform=standalonewindows,android', async () => {
+      const getAllPaginated = jest.fn(() => ({ total: 0, rows: [] }));
+      asMock(getWorldRepository).mockReturnValue(
+        createMockRepo({ getAllPaginated })
+      );
+
+      await app.inject({
+        method: 'GET',
+        url: '/api/worlds?platform=standalonewindows,android',
+        headers: { authorization: 'Bearer test-token' }
+      });
+
+      expect(getAllPaginated).toHaveBeenCalledWith(
+        50,
+        0,
+        expect.objectContaining({ platforms: ['standalonewindows', 'android'] })
+      );
+    });
+
+    it('accepts repeated platform params ?platform=standalonewindows&platform=android', async () => {
+      const getAllPaginated = jest.fn(() => ({ total: 0, rows: [] }));
+      asMock(getWorldRepository).mockReturnValue(
+        createMockRepo({ getAllPaginated })
+      );
+
+      await app.inject({
+        method: 'GET',
+        url: '/api/worlds?platform=standalonewindows&platform=android',
+        headers: { authorization: 'Bearer test-token' }
+      });
+
+      expect(getAllPaginated).toHaveBeenCalledWith(
+        50,
+        0,
+        expect.objectContaining({ platforms: ['standalonewindows', 'android'] })
+      );
+    });
+
     it('passes quality filters to repository', async () => {
       const getAllPaginated = jest.fn(() => ({ total: 0, rows: [] }));
       asMock(getWorldRepository).mockReturnValue(
@@ -410,6 +467,29 @@ describe('API Server', () => {
           quality: ['good'],
           tags: ['horror'],
           search: 'spooky'
+        })
+      );
+    });
+
+    it('combines platform filter with other filters', async () => {
+      const getAllPaginated = jest.fn(() => ({ total: 0, rows: [] }));
+      asMock(getWorldRepository).mockReturnValue(
+        createMockRepo({ getAllPaginated })
+      );
+
+      await app.inject({
+        method: 'GET',
+        url: '/api/worlds?platform=standalonewindows&platform=android&quality=good&tag=horror',
+        headers: { authorization: 'Bearer test-token' }
+      });
+
+      expect(getAllPaginated).toHaveBeenCalledWith(
+        50,
+        0,
+        expect.objectContaining({
+          platforms: ['standalonewindows', 'android'],
+          quality: ['good'],
+          tags: ['horror']
         })
       );
     });

--- a/src/apiServer/routes/worlds.ts
+++ b/src/apiServer/routes/worlds.ts
@@ -26,21 +26,21 @@ function sanitizeRecord(raw: WorldRecord) {
   };
 }
 
-function parseTagQuery(raw: unknown): string[] | undefined {
+function parseStringListQuery(raw: unknown): string[] | undefined {
   if (!raw) return undefined;
 
   const sources = Array.isArray(raw) ? raw.map(String) : [String(raw)];
 
-  const tags = sources
+  const values = sources
     .flatMap((s) => s.split(','))
     .map((s) => s.trim())
     .filter(Boolean);
 
   // Deduplicate while preserving first-appearance order
   const seen = new Set<string>();
-  return tags.filter((t) => {
-    if (seen.has(t)) return false;
-    seen.add(t);
+  return values.filter((v) => {
+    if (seen.has(v)) return false;
+    seen.add(v);
     return true;
   });
 }
@@ -74,7 +74,8 @@ const worldsRoute: FastifyPluginAsync = async (fastify: FastifyInstance) => {
     const limit = Math.min(Number(query.limit ?? 50), 500);
     const offset = Number(query.offset ?? 0);
 
-    const tags = parseTagQuery(query.tag);
+    const tags = parseStringListQuery(query.tag);
+    const platforms = parseStringListQuery(query.platform);
 
     const quality = Array.isArray(query.quality)
       ? query.quality
@@ -115,6 +116,7 @@ const worldsRoute: FastifyPluginAsync = async (fastify: FastifyInstance) => {
     }
 
     const filters: {
+      platforms?: string[];
       tags?: string[];
       quality?: ('good' | 'bad')[];
       search?: string;
@@ -122,6 +124,7 @@ const worldsRoute: FastifyPluginAsync = async (fastify: FastifyInstance) => {
       maxCapacity?: number;
     } = {};
     if (tags) filters.tags = tags;
+    if (platforms) filters.platforms = platforms;
     if (quality) filters.quality = quality;
     if (minCapacity !== undefined) filters.minCapacity = minCapacity;
     if (maxCapacity !== undefined) filters.maxCapacity = maxCapacity;

--- a/src/utils/database/worldRepository.test.ts
+++ b/src/utils/database/worldRepository.test.ts
@@ -622,6 +622,105 @@ describe('WorldRepository', () => {
     });
   });
 
+  describe('platform filtering', () => {
+    beforeEach(() => {
+      db.prepare('DELETE FROM world_records').run();
+
+      repo.upsert(
+        createTestRecord({
+          worldId: 'wrld_pc_only',
+          guildId: 'guild-1',
+          platforms: ['standalonewindows']
+        })
+      );
+      repo.upsert(
+        createTestRecord({
+          worldId: 'wrld_pc_and_android',
+          guildId: 'guild-1',
+          platforms: ['standalonewindows', 'android']
+        })
+      );
+      repo.upsert(
+        createTestRecord({
+          worldId: 'wrld_all_three',
+          guildId: 'guild-1',
+          platforms: ['standalonewindows', 'android', 'ios']
+        })
+      );
+      repo.upsert(
+        createTestRecord({
+          worldId: 'wrld_ios_only',
+          guildId: 'guild-1',
+          platforms: ['ios']
+        })
+      );
+    });
+
+    it('filters by a single platform', () => {
+      const { rows, total } = repo.getAllPaginated(10, 0, {
+        platforms: ['standalonewindows']
+      });
+      expect(total).toBe(3);
+      expect(rows.map((r) => r.worldId).sort()).toEqual([
+        'wrld_all_three',
+        'wrld_pc_and_android',
+        'wrld_pc_only'
+      ]);
+    });
+
+    it('filters by multiple platforms with AND logic', () => {
+      const { rows, total } = repo.getAllPaginated(10, 0, {
+        platforms: ['standalonewindows', 'android']
+      });
+      expect(total).toBe(2);
+      expect(rows.map((r) => r.worldId).sort()).toEqual([
+        'wrld_all_three',
+        'wrld_pc_and_android'
+      ]);
+    });
+
+    it('returns no results when platform does not match', () => {
+      const { rows, total } = repo.getAllPaginated(10, 0, {
+        platforms: ['unknown_platform']
+      });
+      expect(total).toBe(0);
+      expect(rows).toEqual([]);
+    });
+
+    it('combines platform filter with other filters', () => {
+      repo.upsert(
+        createTestRecord({
+          worldId: 'wrld_match',
+          guildId: 'guild-1',
+          platforms: ['standalonewindows', 'android'],
+          tags: ['horror'],
+          capacity: 32
+        })
+      );
+      repo.updateQuality('wrld_match', 'guild-1', 'good');
+      repo.upsert(
+        createTestRecord({
+          worldId: 'wrld_wrong_platform',
+          guildId: 'guild-1',
+          platforms: ['standalonewindows'],
+          tags: ['horror'],
+          capacity: 32
+        })
+      );
+      repo.updateQuality('wrld_wrong_platform', 'guild-1', 'good');
+
+      const { rows, total } = repo.getAllPaginated(10, 0, {
+        platforms: ['android'],
+        tags: ['horror'],
+        quality: ['good'],
+        minCapacity: 10,
+        maxCapacity: 40
+      });
+      expect(total).toBe(1);
+      expect(rows[0].worldId).toBe('wrld_match');
+    });
+  });
+
   describe('getUniqueTags', () => {
     it('returns empty array when no records', () => {
       expect(repo.getUniqueTags()).toEqual([]);

--- a/src/utils/database/worldRepository.ts
+++ b/src/utils/database/worldRepository.ts
@@ -257,13 +257,14 @@ export class WorldRepository {
    * Paginated list of world records with optional filters.
    * @param limit   Max rows to return
    * @param offset  Rows to skip
-   * @param filters Optional filters (tag array = AND logic, guildId, quality)
+   * @param filters Optional filters (tag array = AND logic, platforms array = AND logic, guildId, quality)
    */
   getAllPaginated(
     limit: number,
     offset: number,
     filters?: {
       tags?: string[];
+      platforms?: string[];
       guildId?: string;
       quality?: ('good' | 'bad')[];
       search?: string;
@@ -291,6 +292,15 @@ export class WorldRepository {
           'EXISTS (SELECT 1 FROM json_each(tags) WHERE value = ?)'
         );
         params.push(tag);
+      }
+    }
+
+    if (filters?.platforms && filters.platforms.length > 0) {
+      for (const platform of filters.platforms) {
+        whereParts.push(
+          'EXISTS (SELECT 1 FROM json_each(platforms) WHERE value = ?)'
+        );
+        params.push(platform);
       }
     }
 


### PR DESCRIPTION
## Summary

Adds a new `platform` query parameter to the existing `GET /api/worlds` endpoint, allowing consumers to filter worlds by the platforms they support.

This enables dashboard URLs like:
```
/api/worlds?limit=20&offset=0&minCapacity=1&maxCapacity=80&platform=standalonewindows&platform=android&platform=ios
```

## Changes

- `src/apiServer/routes/worlds.ts`: Accepts `?platform` as a comma-separated or repeated query parameter. Multiple platforms are combined with AND logic.
- `src/utils/database/worldRepository.ts`: Adds `platforms` filter support using SQLite `json_each(platforms)`, consistent with the existing tag filter.
- `src/apiServer/apiServer.test.ts` and `src/utils/database/worldRepository.test.ts`: Added tests for single, comma-separated, repeated, and combined platform filters.
- `manual/API.md`: Documented the new parameter and examples.

## Testing

- Full test suite: `232 passed`
- `pnpm lint`: clean
- `npx tsc --noEmit`: passes

## Checklist

- [x] Tests added/updated
- [x] Documentation updated
- [x] Lint passes
- [x] Type check passes