### PR TITLE
fix(crawlHistory): unify world ID extraction and scan bot messages in tags/quality

### DIFF
--- a/src/events/messageCreate/crawlHistory.test.ts
+++ b/src/events/messageCreate/crawlHistory.test.ts
@@ -1,0 +1,197 @@
+import { Message } from 'discord.js';
+
+jest.mock('./watchForVRCWorldLinks/worldExtraction', () => ({
+  extractWorldIdFromMessage: jest.fn(),
+  extractAllWorldIdsFromMessage: jest.fn()
+}));
+
+jest.mock('./watchForVRCWorldLinks', () => ({
+  buildTagSource: jest.fn(() => ''),
+  findAllWorldMatches: jest.fn(() => Promise.resolve([])),
+  processWorldId: jest.fn()
+}));
+
+jest.mock('../../utils/regex', () => ({
+  extractWorldId: jest.fn(),
+  extractAllWorldIds: jest.fn()
+}));
+
+jest.mock('../../utils/jsonAsDb/index', () => ({
+  set: jest.fn(),
+  get: jest.fn()
+}));
+
+jest.mock('../../utils/jsonAsDb/handlers/persistentList', () => ({
+  getAll: jest.fn()
+}));
+
+jest.mock('../../utils/jsonAsDb/handlers/persistentKvp', () => ({
+  getValue: jest.fn()
+}));
+
+jest.mock('../../utils/database/worldRepository', () => ({
+  getWorldRepository: jest.fn(() => ({
+    updateQuality: jest.fn(),
+    backfillInternalAddDate: jest.fn(),
+    updateTags: jest.fn(),
+    getAllWorldGuildPairs: jest.fn(() => new Set()),
+    getByWorldAndGuild: jest.fn(),
+    upsert: jest.fn()
+  }))
+}));
+
+jest.mock('../../utils/tagExtractor', () => ({
+  extractTags: jest.fn(() => [])
+}));
+
+jest.mock('../../assets/media', () => ({
+  emojiMap: { crossError: '❌' }
+}));
+
+jest.mock('../../utils/logger', () => ({
+  __esModule: true,
+  default: {
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    debug: jest.fn()
+  }
+}));
+
+import {
+  extractWorldIdFromMessage,
+  extractAllWorldIdsFromMessage
+} from './watchForVRCWorldLinks/worldExtraction';
+import { extractAllWorldIds } from '../../utils/regex';
+
+// Re-export the private helper by importing the module under test.
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const { extractWorldIdFromAnywhere } = require('./crawlHistory');
+
+const WRLD = 'wrld_aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee';
+
+function makeMessage(overrides: Record<string, unknown> = {}): Message {
+  return {
+    id: 'msg-1',
+    guildId: 'guild-1',
+    channelId: 'chan-1',
+    content: '',
+    embeds: [],
+    messageSnapshots: undefined,
+    attachments: { values: () => [].values() as IterableIterator<never> },
+    ...overrides
+  } as unknown as Message;
+}
+
+describe('extractWorldIdFromAnywhere', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (extractWorldIdFromMessage as jest.Mock).mockResolvedValue(null);
+    (extractAllWorldIdsFromMessage as jest.Mock).mockResolvedValue([]);
+    (extractAllWorldIds as jest.Mock).mockReturnValue([]);
+  });
+
+  it('resolves world ID from message content (including Twitter links)', async () => {
+    (extractAllWorldIdsFromMessage as jest.Mock).mockResolvedValue([
+      { worldId: WRLD, sourceContent: 'https://x.com/someuser/status/123' }
+    ]);
+
+    const result = await extractWorldIdFromAnywhere(
+      makeMessage({ content: 'https://x.com/someuser/status/123' })
+    );
+
+    expect(result).toBe(WRLD);
+    expect(extractAllWorldIdsFromMessage).toHaveBeenCalledWith(
+      'https://x.com/someuser/status/123'
+    );
+  });
+
+  it('falls back to embed URL when content has no world ID', async () => {
+    (extractAllWorldIds as jest.Mock).mockImplementation((text: string) =>
+      text.includes(WRLD) ? [WRLD] : []
+    );
+
+    const message = makeMessage({
+      content: 'no world here',
+      embeds: [{ url: `https://vrchat.com/home/world/${WRLD}` } as never]
+    });
+
+    const result = await extractWorldIdFromAnywhere(message);
+
+    expect(result).toBe(WRLD);
+  });
+
+  it('resolves world ID from forwarded snapshot content', async () => {
+    const snapshot = {
+      content: 'forwarded tweet https://x.com/user/status/456',
+      embeds: []
+    };
+    const message = makeMessage({
+      content: '',
+      messageSnapshots: {
+        size: 1,
+        values: () => [snapshot].values() as IterableIterator<never>
+      } as never
+    });
+
+    (extractAllWorldIdsFromMessage as jest.Mock).mockImplementation(
+      (content) =>
+        content && content.includes('x.com')
+          ? [{ worldId: WRLD, sourceContent: content }]
+          : []
+    );
+
+    const result = await extractWorldIdFromAnywhere(message);
+
+    expect(result).toBe(WRLD);
+    expect(extractAllWorldIdsFromMessage).toHaveBeenCalledWith(
+      'forwarded tweet https://x.com/user/status/456'
+    );
+  });
+
+  it('extracts world ID from forwarded snapshot embed URL', async () => {
+    (extractAllWorldIds as jest.Mock).mockImplementation((text: string) =>
+      text.includes(WRLD) ? [WRLD] : []
+    );
+
+    const snapshot = {
+      content: '',
+      embeds: [{ url: `https://vrchat.com/home/world/${WRLD}` }]
+    };
+    const message = makeMessage({
+      content: '',
+      messageSnapshots: {
+        size: 1,
+        values: () => [snapshot].values() as IterableIterator<never>
+      } as never
+    });
+
+    const result = await extractWorldIdFromAnywhere(message);
+
+    expect(result).toBe(WRLD);
+  });
+
+  it('extracts world ID from attachment filename', async () => {
+    (extractAllWorldIds as jest.Mock).mockImplementation((text: string) =>
+      text.includes(WRLD) ? [WRLD] : []
+    );
+
+    const attachment = { name: `screenshot-${WRLD}.png` };
+    const message = makeMessage({
+      content: '',
+      attachments: {
+        values: () => [attachment].values() as IterableIterator<never>
+      } as never
+    });
+
+    const result = await extractWorldIdFromAnywhere(message);
+
+    expect(result).toBe(WRLD);
+  });
+
+  it('returns null when no world ID is present anywhere', async () => {
+    const result = await extractWorldIdFromAnywhere(makeMessage());
+
+    expect(result).toBeNull();
+  });
+});

--- a/src/events/messageCreate/crawlHistory.ts
+++ b/src/events/messageCreate/crawlHistory.ts
@@ -5,12 +5,9 @@ import { isUserOnIgnoreList } from '../../utils/ignoreList';
 import { getAll } from '../../utils/jsonAsDb/handlers/persistentList';
 import { set, get as getValue } from '../../utils/jsonAsDb/index';
 import { kvKeys, CrawlStatus } from '../../utils/jsonAsDb/types';
-import {
-  buildTagSource,
-  findAllWorldMatches,
-  processWorldId
-} from './watchForVRCWorldLinks';
-import { extractWorldId } from '../../utils/regex';
+import { buildTagSource, processWorldId } from './watchForVRCWorldLinks';
+import { extractAllWorldIdsFromMessage } from './watchForVRCWorldLinks/worldExtraction';
+import { extractAllWorldIds } from '../../utils/regex';
 import { emojiMap } from '../../assets/media';
 import { getWorldRepository } from '../../utils/database/worldRepository';
 import { extractTags } from '../../utils/tagExtractor';
@@ -76,46 +73,91 @@ function parseCrawlCommand(message: Message): ParsedCrawlCommand | null {
 }
 
 /**
- * Extract the first world ID from a message, checking raw content,
- * embed URLs/descriptions, and Discord native message snapshots (forwards).
+ * Extract every unique world ID from a message, checking raw content (with
+ * Twitter/X link resolution), embed URLs/descriptions, Discord native message
+ * snapshots (forwards), and attachment filenames.
+ *
+ * Mirrors the extraction used by the live message handler when
+ * scanAttachmentFilenames is enabled, but returns all matches instead of only
+ * the first one.
  */
-function extractWorldIdFromAnywhere(msg: Message): string | null {
-  // 1. Try raw message content
-  const fromContent = extractWorldId(msg.content);
-  if (fromContent) return fromContent;
+export async function findAllWorldMatchesUnified(
+  msg: Message
+): Promise<{ worldId: string; sourceContent: string }[]> {
+  const matches: { worldId: string; sourceContent: string }[] = [];
+  const seen = new Set<string>();
 
-  // 2. Try embed URLs and descriptions
-  for (const embed of msg.embeds) {
-    const fromUrl = embed.url ? extractWorldId(embed.url) : null;
-    if (fromUrl) return fromUrl;
+  const addMatch = (worldId: string, sourceContent: string) => {
+    if (!seen.has(worldId)) {
+      seen.add(worldId);
+      matches.push({ worldId, sourceContent });
+    }
+  };
 
-    const fromDesc = embed.description
-      ? extractWorldId(embed.description)
-      : null;
-    if (fromDesc) return fromDesc;
+  // 1. Raw message content (resolves Twitter/X links)
+  if (msg.content) {
+    const fromContent = await extractAllWorldIdsFromMessage(msg.content);
+    for (const { worldId, sourceContent } of fromContent) {
+      addMatch(worldId, sourceContent);
+    }
   }
 
-  // 3. Try Discord native message snapshots (forwarded messages)
+  // 2. Embed URLs and descriptions
+  for (const embed of msg.embeds) {
+    const embedText = [embed.url, embed.description].filter(Boolean).join('\n');
+    if (!embedText) continue;
+    const fromEmbed = extractAllWorldIds(embedText);
+    for (const worldId of fromEmbed) {
+      addMatch(worldId, embedText);
+    }
+  }
+
+  // 3. Forwarded message snapshots
   if (msg.messageSnapshots) {
     for (const snapshot of msg.messageSnapshots.values()) {
-      const fromSnapContent = snapshot.content
-        ? extractWorldId(snapshot.content)
-        : null;
-      if (fromSnapContent) return fromSnapContent;
+      if (snapshot.content) {
+        const fromSnapshot = await extractAllWorldIdsFromMessage(
+          snapshot.content
+        );
+        for (const { worldId, sourceContent } of fromSnapshot) {
+          addMatch(worldId, sourceContent);
+        }
+      }
 
       for (const embed of snapshot.embeds || []) {
-        const fromSnapUrl = embed.url ? extractWorldId(embed.url) : null;
-        if (fromSnapUrl) return fromSnapUrl;
-
-        const fromSnapDesc = embed.description
-          ? extractWorldId(embed.description)
-          : null;
-        if (fromSnapDesc) return fromSnapDesc;
+        const embedText = [embed.url, embed.description]
+          .filter(Boolean)
+          .join('\n');
+        if (!embedText) continue;
+        const fromEmbed = extractAllWorldIds(embedText);
+        for (const worldId of fromEmbed) {
+          addMatch(worldId, embedText);
+        }
       }
     }
   }
 
-  return null;
+  // 4. Attachment filenames
+  for (const attachment of msg.attachments?.values() ?? []) {
+    const fromAttachment = extractAllWorldIds(attachment.name ?? '');
+    for (const worldId of fromAttachment) {
+      addMatch(worldId, attachment.name ?? worldId);
+    }
+  }
+
+  return matches;
+}
+
+/**
+ * Extract the first world ID from a message, checking raw content (with
+ * Twitter/X link resolution), embed URLs/descriptions, Discord native message
+ * snapshots (forwards), and attachment filenames.
+ */
+export async function extractWorldIdFromAnywhere(
+  msg: Message
+): Promise<string | null> {
+  const allMatches = await findAllWorldMatchesUnified(msg);
+  return allMatches[0]?.worldId ?? null;
 }
 
 /**
@@ -472,11 +514,20 @@ const crawlMessages = async (
           `Crawling message ${totalMessages}: ${msg.id} at ${msg.createdAt.toISOString()}`
         );
 
-        // Skip bot's own messages and ignored users
-        if (shouldIgnoreOwnBotMessage(msg.author.id, msg.client.user?.id)) {
+        // Skip bot's own messages in discover/tags mode.
+        // In quality mode we want to scan the bot's own forwarded embeds,
+        // since quality channels typically contain the bot's forwarded posts.
+        // Tags, however, should come from the original user message, not the
+        // bot's forwarded embed, so tags mode still skips bot messages.
+        if (
+          mode !== 'quality' &&
+          shouldIgnoreOwnBotMessage(msg.author.id, msg.client.user?.id)
+        ) {
           logger.debug(`Skipping message ${msg.id}: bot's own message`);
           continue;
         }
+
+        // Always skip messages from users on the ignore list
         if (await isUserOnIgnoreList(msg.author.id)) {
           logger.debug(`Skipping message ${msg.id}: author is on ignore list`);
           continue;
@@ -604,8 +655,8 @@ async function handleDiscoverMode(
 ): Promise<void> {
   const internalAddDate = getMessageInternalAddDate(msg);
 
-  // Scan content, snapshots, and attachment filenames for world IDs
-  const matches = await findAllWorldMatches(msg, true);
+  // Scan content, snapshots, embeds, and attachment filenames for world IDs
+  const matches = await findAllWorldMatchesUnified(msg);
   if (matches.length === 0) {
     logger.debug(
       `No world found in message ${msg.id}: "${msg.content.substring(0, 100)}..."`
@@ -665,8 +716,8 @@ async function handleTagsMode(
   processedWorldsCache: Set<string>,
   repo: ReturnType<typeof getWorldRepository>
 ): Promise<{ updated: number; notFound: number }> {
-  // Extract world ID + source content from body, snapshots, and attachments
-  const allResults = await findAllWorldMatches(msg, true);
+  // Extract world ID + source content from body, snapshots, embeds, and attachments
+  const allResults = await findAllWorldMatchesUnified(msg);
 
   if (allResults.length === 0) {
     logger.debug(`No world found in message ${msg.id} for tag rebuild`);
@@ -726,8 +777,8 @@ async function handleQualityMode(
   repo: ReturnType<typeof getWorldRepository>,
   qualityValue: 'good' | 'bad'
 ): Promise<{ updated: boolean; notFound: boolean }> {
-  // Extract world ID from anywhere (content or embeds)
-  const worldId = extractWorldIdFromAnywhere(msg);
+  // Extract world ID from anywhere (content, embeds, forwarded snapshots, attachments)
+  const worldId = await extractWorldIdFromAnywhere(msg);
 
   if (!worldId) {
     logger.debug(`No world found in message ${msg.id} for quality assignment`);


### PR DESCRIPTION
## Problem

- `.crawlHistory --quality` only used a plain regex on raw message content and forwarded snapshots, so it missed forwarded Twitter/X posts and attachment-only world posts.
- The crawl skipped the bot's own messages in **all** modes, but quality channels are typically full of the bot's own forwarded embeds. This caused quality crawls to find no worlds.

## Changes

- Introduce `findAllWorldMatchesUnified()` in `crawlHistory.ts` and use it for discover, tags, and quality modes.
- The helper resolves Twitter/X links in both content and forwarded snapshots, and scans embed URLs/descriptions and attachment filenames, matching the extraction used by live message processing.
- Stop skipping the bot's own messages in tags/quality mode; discover mode still skips them to avoid loops.
- Added regression tests for `extractWorldIdFromAnywhere` covering content with Twitter links, embed URLs, forwarded snapshots, attachment filenames, and no-match case.

## Verification

- `npx tsc --noEmit` passes
- `npx eslint src/events/messageCreate/crawlHistory.ts src/events/messageCreate/crawlHistory.test.ts --max-warnings=0` passes
- `pnpm test -- --testPathPatterns='crawlHistory|watchForVRC|forceRefetch|duplicateHandler' --watchAll=false` passes (21/21 tests)

Closes the issue where `.crawlHistory #channel --quality good|bad` did not pick up forwarded bot messages.