### PR TITLE
feat(api): wildcard origin matching and DISABLE_API_RESTRICTIONS killswitch

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -19,6 +19,8 @@ API_HOST=0.0.0.0
 # separated by commas). Falls back to EXPORT_API_TOKEN if not set.
 API_TOKEN=
 # Comma-separated list of allowed Origin values for CORS and origin validation.
+# Supports '*' wildcards, e.g. https://*.vercel.app or
+# https://sos-world-dashboard-git-*-teambobo-s-projects.vercel.app.
 # Example: API_ALLOWED_ORIGINS=https://sosd.googoogaagaa.club,https://testnet.googoogaagaa.club
 # Leave empty to allow any origin (current default behavior).
 API_ALLOWED_ORIGINS=
@@ -28,6 +30,10 @@ API_ALLOWED_ORIGINS=
 # Leave empty to skip IP allowlisting. When set, the API trusts loopback proxies
 # (e.g. Caddy/Nginx on the same host) to provide the real client IP.
 API_ALLOWED_IPS=
+
+# Set to true to bypass the API origin and IP allowlists. Intended only for
+# local development in a sandboxed environment. Equivalent to DEV=true.
+DISABLE_API_RESTRICTIONS=false
 
 # SQLite database path for world metadata storage
 DATABASE_PATH=./worlds.db

--- a/src/apiServer/apiServer.restrictions-disabled.test.ts
+++ b/src/apiServer/apiServer.restrictions-disabled.test.ts
@@ -1,0 +1,91 @@
+import { FastifyInstance } from 'fastify';
+
+jest.mock('../assets/config', () => ({
+  API_PORT: 3000,
+  API_TOKEN: ['test-token'],
+  API_ALLOWED_ORIGINS: ['https://allowed.example.com'],
+  API_ALLOWED_IPS: ['203.0.113.42'],
+  DISABLE_API_RESTRICTIONS: true
+}));
+
+jest.mock('../utils/database/worldRepository', () => ({
+  getWorldRepository: jest.fn()
+}));
+
+jest.mock('../utils/logger', () => ({
+  __esModule: true,
+  default: {
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    debug: jest.fn()
+  }
+}));
+
+import { getWorldRepository } from '../utils/database/worldRepository';
+import { createApiServer } from './index';
+
+const asMock = <T extends (...args: any[]) => any>(fn: any) =>
+  fn as jest.MockedFunction<T>;
+
+function createMockRepo() {
+  return {
+    count: jest.fn(() => 1428),
+    getAllPaginated: jest.fn(() => ({ total: 0, rows: [] })),
+    getByWorldId: jest.fn(() => []),
+    getUniqueTags: jest.fn(() => [])
+  };
+}
+
+describe('API Server with restrictions disabled', () => {
+  let app: FastifyInstance;
+
+  beforeEach(() => {
+    app = createApiServer();
+    asMock(getWorldRepository).mockReturnValue(createMockRepo());
+  });
+
+  afterEach(async () => {
+    await app.close();
+    jest.clearAllMocks();
+  });
+
+  it('allows requests from any origin', async () => {
+    const response = await app.inject({
+      method: 'GET',
+      url: '/api/worlds',
+      headers: {
+        authorization: 'Bearer test-token',
+        origin: 'https://evil.example.com'
+      }
+    });
+
+    expect(response.statusCode).toBe(200);
+  });
+
+  it('allows requests without an origin header', async () => {
+    const response = await app.inject({
+      method: 'GET',
+      url: '/api/worlds',
+      headers: {
+        authorization: 'Bearer test-token'
+      }
+    });
+
+    expect(response.statusCode).toBe(200);
+  });
+
+  it('allows requests from any IP', async () => {
+    const response = await app.inject({
+      method: 'GET',
+      url: '/api/worlds',
+      headers: {
+        authorization: 'Bearer test-token',
+        'x-forwarded-for': '198.51.100.99'
+      },
+      remoteAddress: '127.0.0.1'
+    });
+
+    expect(response.statusCode).toBe(200);
+  });
+});

--- a/src/apiServer/apiServer.restrictions.test.ts
+++ b/src/apiServer/apiServer.restrictions.test.ts
@@ -3,8 +3,12 @@ import { FastifyInstance } from 'fastify';
 jest.mock('../assets/config', () => ({
   API_PORT: 3000,
   API_TOKEN: ['test-token'],
-  API_ALLOWED_ORIGINS: ['https://allowed.example.com'],
-  API_ALLOWED_IPS: ['203.0.113.42']
+  API_ALLOWED_ORIGINS: [
+    'https://allowed.example.com',
+    'https://sos-world-dashboard-git-*-teambobo-s-projects.vercel.app'
+  ],
+  API_ALLOWED_IPS: ['203.0.113.42'],
+  DISABLE_API_RESTRICTIONS: false
 }));
 
 jest.mock('../utils/database/worldRepository', () => ({
@@ -82,6 +86,63 @@ describe('API Server origin and IP restrictions', () => {
       url: '/api/worlds',
       headers: {
         authorization: 'Bearer test-token'
+      }
+    });
+
+    expect(response.statusCode).toBe(403);
+    expect(JSON.parse(response.body)).toEqual({ error: 'Forbidden' });
+  });
+
+  it('allows requests from origins matching a wildcard pattern', async () => {
+    const response = await app.inject({
+      method: 'GET',
+      url: '/api/worlds',
+      headers: {
+        authorization: 'Bearer test-token',
+        origin:
+          'https://sos-world-dashboard-git-main-teambobo-s-projects.vercel.app'
+      }
+    });
+
+    expect(response.statusCode).toBe(200);
+  });
+
+  it('allows requests from another origin matching the same wildcard pattern', async () => {
+    const response = await app.inject({
+      method: 'GET',
+      url: '/api/worlds',
+      headers: {
+        authorization: 'Bearer test-token',
+        origin:
+          'https://sos-world-dashboard-git-merge-main-t-453664-teambobo-s-projects.vercel.app'
+      }
+    });
+
+    expect(response.statusCode).toBe(200);
+  });
+
+  it('rejects requests from origins that do not match the wildcard pattern', async () => {
+    const response = await app.inject({
+      method: 'GET',
+      url: '/api/worlds',
+      headers: {
+        authorization: 'Bearer test-token',
+        origin: 'https://evil-dashboard-git-main-teambobo-s-projects.vercel.app'
+      }
+    });
+
+    expect(response.statusCode).toBe(403);
+    expect(JSON.parse(response.body)).toEqual({ error: 'Forbidden' });
+  });
+
+  it('rejects Vercel preview origins not under the teambobo-s-projects team', async () => {
+    const response = await app.inject({
+      method: 'GET',
+      url: '/api/worlds',
+      headers: {
+        authorization: 'Bearer test-token',
+        origin:
+          'https://sos-world-dashboard-git-main-attacker-s-projects.vercel.app'
       }
     });
 

--- a/src/apiServer/apiServer.test.ts
+++ b/src/apiServer/apiServer.test.ts
@@ -5,7 +5,8 @@ jest.mock('../assets/config', () => ({
   API_PORT: 3000,
   API_TOKEN: ['test-token'],
   API_ALLOWED_ORIGINS: [],
-  API_ALLOWED_IPS: []
+  API_ALLOWED_IPS: [],
+  DISABLE_API_RESTRICTIONS: false
 }));
 
 jest.mock('../utils/database/worldRepository', () => ({

--- a/src/apiServer/index.ts
+++ b/src/apiServer/index.ts
@@ -11,13 +11,33 @@ function normalizeOrigin(origin: string): string {
   return origin.trim().replace(/\/$/, '').toLowerCase();
 }
 
+function wildcardToRegex(pattern: string): RegExp {
+  const escaped = pattern.replace(/[.+^${}()|[\]\\]/g, '\\$&');
+  const withWildcard = escaped.replace(/\*/g, '[^/]*');
+  return new RegExp(`^${withWildcard}$`, 'i');
+}
+
+function matchesAllowedOrigin(origin: string, allowed: string): boolean {
+  const normalizedOrigin = normalizeOrigin(origin);
+  const normalizedAllowed = normalizeOrigin(allowed);
+
+  if (normalizedAllowed.includes('*')) {
+    return wildcardToRegex(normalizedAllowed).test(normalizedOrigin);
+  }
+
+  return normalizedOrigin === normalizedAllowed;
+}
+
 function isAllowedOrigin(origin: string | undefined): boolean {
   if (Config.API_ALLOWED_ORIGINS.length === 0) return true;
   if (!origin) return false;
-  const normalized = normalizeOrigin(origin);
-  return Config.API_ALLOWED_ORIGINS.some(
-    (allowed) => normalizeOrigin(allowed) === normalized
+  return Config.API_ALLOWED_ORIGINS.some((allowed) =>
+    matchesAllowedOrigin(origin, allowed)
   );
+}
+
+function areApiRestrictionsDisabled(): boolean {
+  return Config.DISABLE_API_RESTRICTIONS === true;
 }
 
 function isAllowedIp(ip: string | undefined): boolean {
@@ -38,9 +58,19 @@ export function createApiServer() {
   registerErrorHandler(fastify);
 
   // CORS: allow configured origins, or fall back to wildcard for backwards compatibility.
-  const corsOptions =
-    Config.API_ALLOWED_ORIGINS.length > 0
-      ? { origin: Config.API_ALLOWED_ORIGINS }
+  // Patterns may contain '*' as a wildcard for one path/domain segment.
+  const restrictionsDisabled = areApiRestrictionsDisabled();
+  const corsOptions = restrictionsDisabled
+    ? { origin: '*' }
+    : Config.API_ALLOWED_ORIGINS.length > 0
+      ? {
+          origin: (
+            origin: string | undefined,
+            cb: (err: Error | null, allow: boolean) => void
+          ) => {
+            cb(null, isAllowedOrigin(origin));
+          }
+        }
       : { origin: '*' };
   void fastify.register(cors, corsOptions);
 
@@ -48,8 +78,11 @@ export function createApiServer() {
   fastify.addHook('onRequest', async (request, reply) => {
     if (request.url === '/api/health') return;
 
-    const hasOriginRules = Config.API_ALLOWED_ORIGINS.length > 0;
-    const hasIpRules = Config.API_ALLOWED_IPS.length > 0;
+    const restrictionsDisabled = areApiRestrictionsDisabled();
+    const hasOriginRules =
+      !restrictionsDisabled && Config.API_ALLOWED_ORIGINS.length > 0;
+    const hasIpRules =
+      !restrictionsDisabled && Config.API_ALLOWED_IPS.length > 0;
 
     // Nothing configured; let auth handle access control.
     if (!hasOriginRules && !hasIpRules) return;

--- a/src/assets/config.ts
+++ b/src/assets/config.ts
@@ -32,7 +32,10 @@ const Config = {
     : [],
   API_ALLOWED_IPS: process.env.API_ALLOWED_IPS
     ? process.env.API_ALLOWED_IPS.split(',').map((ip) => ip.trim())
-    : []
+    : [],
+  DISABLE_API_RESTRICTIONS:
+    process.env.DISABLE_API_RESTRICTIONS === 'true' ||
+    process.env.DEV === 'true'
 };
 
 export default Config;


### PR DESCRIPTION
Adds wildcard support to API_ALLOWED_ORIGINS and a DISABLE_API_RESTRICTIONS env var for local development.

## Changes
- Support '*' wildcards in API_ALLOWED_ORIGINS (e.g. Vercel preview URLs).
- Pin the default Vercel preview pattern to the teambobo-s-projects team to prevent spoofing.
- Add DISABLE_API_RESTRICTIONS env var; also auto-enabled when DEV=true.
- Add tests for wildcard matching and the killswitch.

## Verification
- npx jest src/apiServer/ --no-coverage: 48 tests pass
- npx eslint src/apiServer/ src/assets/config.ts: clean
- npx tsc --noEmit: clean