### PR TITLE
[FEAT] Implement /api/filter-counts for quality and platform facet counts

### DIFF
--- a/src/apiServer/apiServer.restrictions.test.ts
+++ b/src/apiServer/apiServer.restrictions.test.ts
@@ -32,7 +32,11 @@ function createMockRepo() {
     count: jest.fn(() => 1428),
     getAllPaginated: jest.fn(() => ({ total: 0, rows: [] })),
     getByWorldId: jest.fn(() => []),
-    getUniqueTags: jest.fn(() => [])
+    getUniqueTags: jest.fn(() => []),
+    getFilterCounts: jest.fn(() => ({
+      qualityCounts: [],
+      platformCounts: []
+    }))
   };
 }
 

--- a/src/apiServer/apiServer.test.ts
+++ b/src/apiServer/apiServer.test.ts
@@ -70,6 +70,17 @@ function createMockRepo(overrides: Record<string, unknown> = {}) {
       { tag: 'horror', count: 312 },
       { tag: 'game', count: 145 }
     ]),
+    getFilterCounts: jest.fn(() => ({
+      qualityCounts: [
+        { quality: 'good', count: 123 },
+        { quality: 'bad', count: 12 }
+      ],
+      platformCounts: [
+        { platform: 'standalonewindows', count: 80 },
+        { platform: 'android', count: 45 },
+        { platform: 'ios', count: 6 }
+      ]
+    })),
     ...overrides
   };
 }
@@ -684,6 +695,125 @@ describe('API Server', () => {
         { tag: 'horror', count: 312 },
         { tag: 'game', count: 145 }
       ]);
+    });
+  });
+
+  describe('GET /api/filter-counts', () => {
+    it('returns quality and platform counts', async () => {
+      asMock(getWorldRepository).mockReturnValue(createMockRepo());
+
+      const response = await app.inject({
+        method: 'GET',
+        url: '/api/filter-counts',
+        headers: { authorization: 'Bearer test-token' }
+      });
+
+      expect(response.statusCode).toBe(200);
+      const body = JSON.parse(response.body);
+      expect(body.qualityCounts).toEqual([
+        { quality: 'good', count: 123 },
+        { quality: 'bad', count: 12 }
+      ]);
+      expect(body.platformCounts).toEqual([
+        { platform: 'standalonewindows', count: 80 },
+        { platform: 'android', count: 45 },
+        { platform: 'ios', count: 6 }
+      ]);
+    });
+
+    it('passes all filter query params to repository', async () => {
+      const getFilterCounts = jest.fn(() => ({
+        qualityCounts: [],
+        platformCounts: []
+      }));
+      asMock(getWorldRepository).mockReturnValue(
+        createMockRepo({ getFilterCounts })
+      );
+
+      await app.inject({
+        method: 'GET',
+        url: '/api/filter-counts?search=test&minCapacity=10&maxCapacity=40&tag=chill&quality=good&platform=android',
+        headers: { authorization: 'Bearer test-token' }
+      });
+
+      expect(getFilterCounts).toHaveBeenCalledWith(
+        expect.objectContaining({
+          search: 'test',
+          minCapacity: 10,
+          maxCapacity: 40,
+          tags: ['chill'],
+          quality: ['good'],
+          platforms: ['android']
+        })
+      );
+    });
+
+    it('accepts repeated tag, quality and platform params', async () => {
+      const getFilterCounts = jest.fn(() => ({
+        qualityCounts: [],
+        platformCounts: []
+      }));
+      asMock(getWorldRepository).mockReturnValue(
+        createMockRepo({ getFilterCounts })
+      );
+
+      await app.inject({
+        method: 'GET',
+        url: '/api/filter-counts?tag=horror&tag=game&quality=good&quality=bad&platform=android&platform=ios',
+        headers: { authorization: 'Bearer test-token' }
+      });
+
+      expect(getFilterCounts).toHaveBeenCalledWith(
+        expect.objectContaining({
+          tags: ['horror', 'game'],
+          quality: ['good', 'bad'],
+          platforms: ['android', 'ios']
+        })
+      );
+    });
+
+    it('ignores empty or whitespace-only search query', async () => {
+      const getFilterCounts = jest.fn(() => ({
+        qualityCounts: [],
+        platformCounts: []
+      }));
+      asMock(getWorldRepository).mockReturnValue(
+        createMockRepo({ getFilterCounts })
+      );
+
+      await app.inject({
+        method: 'GET',
+        url: '/api/filter-counts?search=%20%20',
+        headers: { authorization: 'Bearer test-token' }
+      });
+
+      expect(getFilterCounts).toHaveBeenCalledWith(undefined);
+    });
+
+    it('returns 400 when minCapacity is greater than maxCapacity', async () => {
+      const response = await app.inject({
+        method: 'GET',
+        url: '/api/filter-counts?minCapacity=50&maxCapacity=20',
+        headers: { authorization: 'Bearer test-token' }
+      });
+
+      expect(response.statusCode).toBe(400);
+      expect(JSON.parse(response.body)).toEqual({
+        error: 'minCapacity must be less than or equal to maxCapacity'
+      });
+    });
+
+    it('returns 400 when capacity value is out of range', async () => {
+      const response = await app.inject({
+        method: 'GET',
+        url: '/api/filter-counts?minCapacity=0',
+        headers: { authorization: 'Bearer test-token' }
+      });
+
+      expect(response.statusCode).toBe(400);
+      expect(JSON.parse(response.body)).toEqual({
+        error: 'minCapacity must be at least 1'
+      });
     });
   });
 

--- a/src/apiServer/index.ts
+++ b/src/apiServer/index.ts
@@ -5,6 +5,7 @@ import Config from '../assets/config';
 import healthRoute from './routes/health';
 import worldsRoute from './routes/worlds';
 import tagsRoute from './routes/tags';
+import filterCountsRoute from './routes/filterCounts';
 import registerErrorHandler from './plugins/errorHandler';
 
 function normalizeOrigin(origin: string): string {
@@ -82,6 +83,7 @@ export function createApiServer() {
   fastify.register(healthRoute);
   fastify.register(worldsRoute);
   fastify.register(tagsRoute);
+  fastify.register(filterCountsRoute);
 
   return fastify;
 }

--- a/src/apiServer/routes/filterCounts.ts
+++ b/src/apiServer/routes/filterCounts.ts
@@ -1,44 +1,16 @@
 import { FastifyInstance, FastifyPluginAsync } from 'fastify';
 import { getWorldRepository } from '../../utils/database/worldRepository';
-import type { WorldRecord } from '../../utils/database/worldRepository';
 import { parseIntegerParam, parseStringListQuery } from '../utils/queryParams';
 
-function toDateString(timestamp: number | undefined): string | undefined {
-  if (!timestamp) return undefined;
-  return new Date(timestamp * 1000).toISOString();
-}
-
-function buildWorldUrl(worldId: string): string {
-  return `https://vrchat.com/home/world/${worldId}`;
-}
-
-function sanitizeRecord(raw: WorldRecord) {
-  return {
-    worldId: raw.worldId,
-    name: raw.name,
-    authorName: raw.authorName,
-    capacity: raw.capacity,
-    platforms: raw.platforms,
-    tags: raw.tags,
-    imageUrl: raw.imageUrl,
-    vrchatUrl: buildWorldUrl(raw.worldId),
-    quality: raw.quality ?? null,
-    createdAt: toDateString(raw.createdAt),
-    internalAddDate: toDateString(raw.internalAddDate ?? undefined)
-  };
-}
-
-const worldsRoute: FastifyPluginAsync = async (fastify: FastifyInstance) => {
-  // GET /api/worlds
-  fastify.get('/api/worlds', async (request, reply) => {
+const filterCountsRoute: FastifyPluginAsync = async (
+  fastify: FastifyInstance
+) => {
+  // GET /api/filter-counts
+  fastify.get('/api/filter-counts', async (request, reply) => {
     const query = request.query as Record<string, unknown>;
-
-    const limit = Math.min(Number(query.limit ?? 50), 500);
-    const offset = Number(query.offset ?? 0);
 
     const tags = parseStringListQuery(query.tag);
     const platforms = parseStringListQuery(query.platform);
-    const worldIds = parseStringListQuery(query.worldId);
 
     const quality = Array.isArray(query.quality)
       ? query.quality
@@ -85,11 +57,9 @@ const worldsRoute: FastifyPluginAsync = async (fastify: FastifyInstance) => {
       search?: string;
       minCapacity?: number;
       maxCapacity?: number;
-      worldIds?: string[];
     } = {};
     if (tags) filters.tags = tags;
     if (platforms) filters.platforms = platforms;
-    if (worldIds) filters.worldIds = worldIds;
     if (quality) filters.quality = quality;
     if (minCapacity !== undefined) filters.minCapacity = minCapacity;
     if (maxCapacity !== undefined) filters.maxCapacity = maxCapacity;
@@ -98,32 +68,13 @@ const worldsRoute: FastifyPluginAsync = async (fastify: FastifyInstance) => {
       typeof query.search === 'string' ? query.search.trim() : undefined;
     if (search) filters.search = search;
 
-    const { rows, total } = getWorldRepository().getAllPaginated(
-      limit,
-      offset,
-      Object.keys(filters).length > 0 ? filters : undefined
-    );
+    const { qualityCounts, platformCounts } =
+      getWorldRepository().getFilterCounts(
+        Object.keys(filters).length > 0 ? filters : undefined
+      );
 
-    return {
-      total,
-      limit,
-      offset,
-      worlds: rows.map(sanitizeRecord)
-    };
-  });
-
-  // GET /api/worlds/:worldId
-  fastify.get('/api/worlds/:worldId', async (request, reply) => {
-    const { worldId } = request.params as { worldId: string };
-    const matches = getWorldRepository().getByWorldId(worldId);
-
-    if (matches.length === 0) {
-      return reply.code(404).send({ error: 'World not found' });
-    }
-
-    // Return first live match (most recent by created_at DESC)
-    return sanitizeRecord(matches[0]);
+    return { qualityCounts, platformCounts };
   });
 };
 
-export default worldsRoute;
+export default filterCountsRoute;

--- a/src/apiServer/routes/worlds.ts
+++ b/src/apiServer/routes/worlds.ts
@@ -1,6 +1,10 @@
 import { FastifyInstance, FastifyPluginAsync } from 'fastify';
 import { getWorldRepository } from '../../utils/database/worldRepository';
 import type { WorldRecord } from '../../utils/database/worldRepository';
+import {
+  parseIntegerParam,
+  parseStringListQuery
+} from '../utils/queryParams';
 
 function toDateString(timestamp: number | undefined): string | undefined {
   if (!timestamp) return undefined;
@@ -25,46 +29,6 @@ function sanitizeRecord(raw: WorldRecord) {
     createdAt: toDateString(raw.createdAt),
     internalAddDate: toDateString(raw.internalAddDate ?? undefined)
   };
-}
-
-function parseStringListQuery(raw: unknown): string[] | undefined {
-  if (!raw) return undefined;
-
-  const sources = Array.isArray(raw) ? raw.map(String) : [String(raw)];
-
-  const values = sources
-    .flatMap((s) => s.split(','))
-    .map((s) => s.trim())
-    .filter(Boolean);
-
-  // Deduplicate while preserving first-appearance order
-  const seen = new Set<string>();
-  return values.filter((v) => {
-    if (seen.has(v)) return false;
-    seen.add(v);
-    return true;
-  });
-}
-
-function parseIntegerParam(
-  raw: unknown,
-  options: { min?: number; max?: number; name: string }
-): number | undefined {
-  if (raw === undefined || raw === null || raw === '') return undefined;
-
-  const value = Number(raw);
-  if (!Number.isInteger(value)) {
-    throw new Error(`${options.name} must be an integer`);
-  }
-
-  if (options.min !== undefined && value < options.min) {
-    throw new Error(`${options.name} must be at least ${options.min}`);
-  }
-  if (options.max !== undefined && value > options.max) {
-    throw new Error(`${options.name} must be at most ${options.max}`);
-  }
-
-  return value;
 }
 
 const worldsRoute: FastifyPluginAsync = async (fastify: FastifyInstance) => {

--- a/src/apiServer/utils/queryParams.ts
+++ b/src/apiServer/utils/queryParams.ts
@@ -1,0 +1,39 @@
+export function parseStringListQuery(raw: unknown): string[] | undefined {
+  if (!raw) return undefined;
+
+  const sources = Array.isArray(raw) ? raw.map(String) : [String(raw)];
+
+  const values = sources
+    .flatMap((s) => s.split(','))
+    .map((s) => s.trim())
+    .filter(Boolean);
+
+  // Deduplicate while preserving first-appearance order
+  const seen = new Set<string>();
+  return values.filter((v) => {
+    if (seen.has(v)) return false;
+    seen.add(v);
+    return true;
+  });
+}
+
+export function parseIntegerParam(
+  raw: unknown,
+  options: { min?: number; max?: number; name: string }
+): number | undefined {
+  if (raw === undefined || raw === null || raw === '') return undefined;
+
+  const value = Number(raw);
+  if (!Number.isInteger(value)) {
+    throw new Error(`${options.name} must be an integer`);
+  }
+
+  if (options.min !== undefined && value < options.min) {
+    throw new Error(`${options.name} must be at least ${options.min}`);
+  }
+  if (options.max !== undefined && value > options.max) {
+    throw new Error(`${options.name} must be at most ${options.max}`);
+  }
+
+  return value;
+}

--- a/src/utils/database/worldRepository.test.ts
+++ b/src/utils/database/worldRepository.test.ts
@@ -1006,9 +1006,7 @@ describe('WorldRepository', () => {
         { quality: 'good', count: 1 },
         { quality: 'bad', count: 0 }
       ]);
-      expect(result.platformCounts).toEqual([
-        { platform: 'ios', count: 1 }
-      ]);
+      expect(result.platformCounts).toEqual([{ platform: 'ios', count: 1 }]);
     });
 
     it('applies capacity filters to both quality and platform counts', () => {
@@ -1030,9 +1028,9 @@ describe('WorldRepository', () => {
       expect(
         result.qualityCounts.find((q) => q.quality === 'good')?.count
       ).toBe(1);
-      expect(
-        result.qualityCounts.find((q) => q.quality === 'bad')?.count
-      ).toBe(1);
+      expect(result.qualityCounts.find((q) => q.quality === 'bad')?.count).toBe(
+        1
+      );
     });
 
     it('counts a multi-platform world once per platform', () => {

--- a/src/utils/database/worldRepository.test.ts
+++ b/src/utils/database/worldRepository.test.ts
@@ -895,6 +895,172 @@ describe('WorldRepository', () => {
     });
   });
 
+  describe('getFilterCounts', () => {
+    beforeEach(() => {
+      db.prepare('DELETE FROM world_records').run();
+
+      repo.upsert(
+        createTestRecord({
+          worldId: 'wrld_good_pc',
+          guildId: 'guild-1',
+          platforms: ['standalonewindows'],
+          tags: ['horror'],
+          capacity: 32
+        })
+      );
+      repo.updateQuality('wrld_good_pc', 'guild-1', 'good');
+
+      repo.upsert(
+        createTestRecord({
+          worldId: 'wrld_bad_android',
+          guildId: 'guild-1',
+          platforms: ['android'],
+          tags: ['horror'],
+          capacity: 16
+        })
+      );
+      repo.updateQuality('wrld_bad_android', 'guild-1', 'bad');
+
+      repo.upsert(
+        createTestRecord({
+          worldId: 'wrld_good_ios',
+          guildId: 'guild-1',
+          platforms: ['ios'],
+          tags: ['game'],
+          capacity: 8
+        })
+      );
+      repo.updateQuality('wrld_good_ios', 'guild-1', 'good');
+
+      repo.upsert(
+        createTestRecord({
+          worldId: 'wrld_unrated',
+          guildId: 'guild-1',
+          platforms: ['standalonewindows', 'android'],
+          tags: ['horror'],
+          capacity: 24
+        })
+      );
+    });
+
+    it('returns quality and platform counts for all records', () => {
+      const result = repo.getFilterCounts();
+
+      expect(result.qualityCounts).toEqual([
+        { quality: 'good', count: 2 },
+        { quality: 'bad', count: 1 }
+      ]);
+      expect(result.platformCounts).toEqual([
+        { platform: 'android', count: 2 },
+        { platform: 'standalonewindows', count: 2 },
+        { platform: 'ios', count: 1 }
+      ]);
+    });
+
+    it('returns zero quality counts when no records match', () => {
+      const result = repo.getFilterCounts({ tags: ['nonexistent'] });
+
+      expect(result.qualityCounts).toEqual([
+        { quality: 'good', count: 0 },
+        { quality: 'bad', count: 0 }
+      ]);
+      expect(result.platformCounts).toEqual([]);
+    });
+
+    it('ignores the selected quality filter when counting qualities', () => {
+      const result = repo.getFilterCounts({ quality: ['good'] });
+
+      expect(result.qualityCounts).toEqual([
+        { quality: 'good', count: 2 },
+        { quality: 'bad', count: 1 }
+      ]);
+    });
+
+    it('ignores the selected platform filter when counting platforms', () => {
+      const result = repo.getFilterCounts({ platforms: ['standalonewindows'] });
+
+      expect(result.platformCounts).toEqual([
+        { platform: 'android', count: 2 },
+        { platform: 'standalonewindows', count: 2 },
+        { platform: 'ios', count: 1 }
+      ]);
+    });
+
+    it('applies tag filters to both quality and platform counts', () => {
+      const result = repo.getFilterCounts({ tags: ['horror'] });
+
+      expect(result.qualityCounts).toEqual([
+        { quality: 'good', count: 1 },
+        { quality: 'bad', count: 1 }
+      ]);
+      expect(result.platformCounts).toEqual([
+        { platform: 'android', count: 2 },
+        { platform: 'standalonewindows', count: 2 }
+      ]);
+    });
+
+    it('applies search filters to both quality and platform counts', () => {
+      const result = repo.getFilterCounts({ search: 'ios' });
+
+      expect(result.qualityCounts).toEqual([
+        { quality: 'good', count: 1 },
+        { quality: 'bad', count: 0 }
+      ]);
+      expect(result.platformCounts).toEqual([
+        { platform: 'ios', count: 1 }
+      ]);
+    });
+
+    it('applies capacity filters to both quality and platform counts', () => {
+      const result = repo.getFilterCounts({ minCapacity: 10, maxCapacity: 30 });
+
+      expect(result.qualityCounts).toEqual([
+        { quality: 'good', count: 0 },
+        { quality: 'bad', count: 1 }
+      ]);
+      expect(result.platformCounts).toEqual([
+        { platform: 'android', count: 2 },
+        { platform: 'standalonewindows', count: 1 }
+      ]);
+    });
+
+    it('excludes worlds without a quality from quality counts', () => {
+      const result = repo.getFilterCounts({ tags: ['horror'] });
+
+      expect(
+        result.qualityCounts.find((q) => q.quality === 'good')?.count
+      ).toBe(1);
+      expect(
+        result.qualityCounts.find((q) => q.quality === 'bad')?.count
+      ).toBe(1);
+    });
+
+    it('counts a multi-platform world once per platform', () => {
+      const result = repo.getFilterCounts({ worldIds: ['wrld_unrated'] });
+
+      expect(result.platformCounts).toEqual([
+        { platform: 'android', count: 1 },
+        { platform: 'standalonewindows', count: 1 }
+      ]);
+    });
+
+    it('combines quality and platform filters for the opposite facet', () => {
+      const result = repo.getFilterCounts({
+        quality: ['good'],
+        platforms: ['standalonewindows']
+      });
+
+      expect(result.qualityCounts).toEqual([
+        { quality: 'good', count: 1 },
+        { quality: 'bad', count: 0 }
+      ]);
+      expect(result.platformCounts).toEqual([
+        { platform: 'ios', count: 1 },
+        { platform: 'standalonewindows', count: 1 }
+      ]);
+    });
+  });
+
   describe('getUniqueTags', () => {
     it('returns empty array when no records', () => {
       expect(repo.getUniqueTags()).toEqual([]);

--- a/src/utils/database/worldRepository.ts
+++ b/src/utils/database/worldRepository.ts
@@ -291,25 +291,20 @@ export class WorldRepository {
   }
 
   /**
-   * Paginated list of world records with optional filters.
-   * @param limit   Max rows to return
-   * @param offset  Rows to skip
-   * @param filters Optional filters (tag array = AND logic, platforms array = AND logic, guildId, quality)
+   * Build a WHERE clause and parameter list from the given filters.
+   * Used by getAllPaginated and getFilterCounts so facet counts use the
+   * exact same filtering rules as the paginated world list.
    */
-  getAllPaginated(
-    limit: number,
-    offset: number,
-    filters?: {
-      tags?: string[];
-      platforms?: string[];
-      guildId?: string;
-      quality?: ('good' | 'bad')[];
-      search?: string;
-      minCapacity?: number;
-      maxCapacity?: number;
-      worldIds?: string[];
-    }
-  ): { rows: WorldRecord[]; total: number } {
+  private buildWhereClause(filters?: {
+    tags?: string[];
+    platforms?: string[];
+    guildId?: string;
+    quality?: ('good' | 'bad')[];
+    search?: string;
+    minCapacity?: number;
+    maxCapacity?: number;
+    worldIds?: string[];
+  }): { whereClause: string; params: (string | number)[] } {
     const whereParts: string[] = [];
     const params: (string | number)[] = [];
 
@@ -379,6 +374,31 @@ export class WorldRepository {
     const whereClause =
       whereParts.length > 0 ? `WHERE ${whereParts.join(' AND ')}` : '';
 
+    return { whereClause, params };
+  }
+
+  /**
+   * Paginated list of world records with optional filters.
+   * @param limit   Max rows to return
+   * @param offset  Rows to skip
+   * @param filters Optional filters (tag array = AND logic, platforms array = AND logic, guildId, quality)
+   */
+  getAllPaginated(
+    limit: number,
+    offset: number,
+    filters?: {
+      tags?: string[];
+      platforms?: string[];
+      guildId?: string;
+      quality?: ('good' | 'bad')[];
+      search?: string;
+      minCapacity?: number;
+      maxCapacity?: number;
+      worldIds?: string[];
+    }
+  ): { rows: WorldRecord[]; total: number } {
+    const { whereClause, params } = this.buildWhereClause(filters);
+
     const countSql = `SELECT COUNT(*) as total FROM world_records ${whereClause}`;
     const countStmt = this.db.prepare(countSql);
     const countRow = countStmt.get(...params) as { total: number } | undefined;
@@ -394,6 +414,70 @@ export class WorldRepository {
     return {
       rows: rows.map(rowToRecord),
       total
+    };
+  }
+
+  /**
+   * Return facet counts for quality and platform options given the current
+   * filter context. Quality counts ignore the selected quality filter, and
+   * platform counts ignore the selected platform filter, matching standard
+   * faceted search behavior.
+   */
+  getFilterCounts(filters?: {
+    tags?: string[];
+    platforms?: string[];
+    guildId?: string;
+    quality?: ('good' | 'bad')[];
+    search?: string;
+    minCapacity?: number;
+    maxCapacity?: number;
+    worldIds?: string[];
+  }): {
+    qualityCounts: { quality: 'good' | 'bad'; count: number }[];
+    platformCounts: { platform: string; count: number }[];
+  } {
+    const qualityBase = { ...filters, quality: undefined };
+    const { whereClause: qualityWhere, params: qualityParams } =
+      this.buildWhereClause(qualityBase);
+
+    const qualityWhereWithQuality = qualityWhere
+      ? `${qualityWhere} AND quality IN ('good', 'bad')`
+      : "WHERE quality IN ('good', 'bad')";
+
+    const qualitySql = `
+      SELECT q.quality, COALESCE(c.count, 0) as count
+      FROM (SELECT 'good' as quality UNION ALL SELECT 'bad' as quality) q
+      LEFT JOIN (
+        SELECT quality, COUNT(*) as count
+        FROM world_records
+        ${qualityWhereWithQuality}
+        GROUP BY quality
+      ) c ON c.quality = q.quality
+    `;
+    const qualityStmt = this.db.prepare(qualitySql);
+    const qualityRows = qualityStmt.all(
+      ...qualityParams
+    ) as { quality: 'good' | 'bad'; count: number }[];
+
+    const platformBase = { ...filters, platforms: undefined };
+    const { whereClause: platformWhere, params: platformParams } =
+      this.buildWhereClause(platformBase);
+
+    const platformSql = `
+      SELECT value as platform, COUNT(*) as count
+      FROM world_records, json_each(platforms)
+      ${platformWhere}
+      GROUP BY value
+      ORDER BY count DESC, platform ASC
+    `;
+    const platformStmt = this.db.prepare(platformSql);
+    const platformRows = platformStmt.all(
+      ...platformParams
+    ) as { platform: string; count: number }[];
+
+    return {
+      qualityCounts: qualityRows,
+      platformCounts: platformRows
     };
   }
 

--- a/src/utils/database/worldRepository.ts
+++ b/src/utils/database/worldRepository.ts
@@ -455,9 +455,10 @@ export class WorldRepository {
       ) c ON c.quality = q.quality
     `;
     const qualityStmt = this.db.prepare(qualitySql);
-    const qualityRows = qualityStmt.all(
-      ...qualityParams
-    ) as { quality: 'good' | 'bad'; count: number }[];
+    const qualityRows = qualityStmt.all(...qualityParams) as {
+      quality: 'good' | 'bad';
+      count: number;
+    }[];
 
     const platformBase = { ...filters, platforms: undefined };
     const { whereClause: platformWhere, params: platformParams } =
@@ -471,9 +472,10 @@ export class WorldRepository {
       ORDER BY count DESC, platform ASC
     `;
     const platformStmt = this.db.prepare(platformSql);
-    const platformRows = platformStmt.all(
-      ...platformParams
-    ) as { platform: string; count: number }[];
+    const platformRows = platformStmt.all(...platformParams) as {
+      platform: string;
+      count: number;
+    }[];
 
     return {
       qualityCounts: qualityRows,


### PR DESCRIPTION
Implements the backend contract required by https://github.com/Moistbobo/sos-world-dashboard/pull/82.

## Summary

- Adds a new `GET /api/filter-counts` endpoint that returns quality and platform facet counts for the currently applied filters.
- Refactors shared query-parameter parsing and WHERE-clause construction so `/api/worlds` and `/api/filter-counts` behave consistently.
- Quality counts ignore the selected `quality` filter; platform counts ignore the selected `platform` filter, matching standard faceted-search behavior.
- Supports the same filter parameters as `/api/worlds`: `search`, `minCapacity`, `maxCapacity`, `tag`, `quality`, and `platform`.

## Test Plan

- [x] `pnpm test` passes (274 tests)
- [x] `pnpm lint` passes (0 warnings)

## New API contract

```
GET /api/filter-counts?search=test&minCapacity=10&maxCapacity=40&tag=chill&quality=good&platform=android

{
  "qualityCounts": [
    { "quality": "good", "count": 123 },
    { "quality": "bad", "count": 12 }
  ],
  "platformCounts": [
    { "platform": "standalonewindows", "count": 80 },
    { "platform": "android", "count": 45 },
    { "platform": "ios", "count": 6 }
  ]
}
```
