### PR TITLE
[FEAT]: Add dayRange filter to GET /api/worlds

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,7 +295,7 @@ The bot includes a built-in Fastify REST API server for querying world records. 
 | Endpoint | Description | Auth |
 |----------|-------------|------|
 | `GET /api/health` | Health check | No |
-| `GET /api/worlds` | Paginated world list with tag/quality filters | Bearer token |
+| `GET /api/worlds` | Paginated world list with tag/quality/capacity/dayRange filters | Bearer token |
 | `GET /api/worlds/:worldId` | Single world record | Bearer token |
 | `GET /api/tags` | All unique tags with occurrence counts | Bearer token |
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -160,6 +160,7 @@ Returns a paginated, filterable list of world records.
 | `minCapacity` | integer           | —       | —   | Minimum world capacity (inclusive). Must be ≥ 1 and ≤ 80. |
 | `maxCapacity` | integer           | —       | —   | Maximum world capacity (inclusive). Must be ≥ 1 and ≤ 80. |
 | `worldId`     | string / string[] | —       | —   | Filter to specific world ID(s). Comma-separated or repeated. Exact match only. |
+| `dayRange`    | integer           | —       | 365 | Return only worlds tagged within the last N days. Values below `0` are treated as `0` (no filter); values above `365` are clamped to `365`. Tagged date uses `internal_add_date` when present, otherwise falls back to `created_at`. |
 
 **Response**
 
@@ -242,12 +243,28 @@ GET /api/worlds?worldId=wrld_abc123&worldId=wrld_def456
 
 This is useful for batch lookups when you already have a list of world IDs.
 
+**Filtering by date tagged**
+
+To show only worlds that were tagged in the system within the last N days, use the `dayRange` parameter:
+
+```
+GET /api/worlds?dayRange=7
+GET /api/worlds?dayRange=1
+GET /api/worlds?dayRange=365
+```
+
+- `dayRange` is clamped to `0–365` days.
+- A value of `0` (or missing/invalid values) disables the date filter.
+- The tagged date is `internal_add_date` when set; otherwise it falls back to `created_at`.
+- Boundaries are computed in UTC using Unix timestamps.
+
 **Combining filters**
 
-Tag, platform, quality, search, and capacity filters work together with AND logic:
+Tag, platform, quality, search, capacity, and date filters work together with AND logic:
 
 ```
 GET /api/worlds?minCapacity=10&maxCapacity=40&quality=good&tag=horror&platform=android
+GET /api/worlds?dayRange=7&tag=horror&quality=good
 ```
 
 **Pagination**
@@ -365,18 +382,19 @@ Returns high-level dataset counts for quality ratings and platform support acros
 
 Each world object returned by the API has the following fields:
 
-| Field         | Type                     | Description |
-|---------------|--------------------------|-------------|
-| `worldId`     | string                   | VRChat world ID (e.g. `wrld_abc123`). |
-| `name`        | string \| null           | Display name of the world. |
-| `authorName`  | string \| null           | Name of the author / creator. |
-| `capacity`    | number \| null           | Maximum player capacity. |
-| `platforms`   | string[]                 | Supported platforms (`android`, `standalonewindows`, etc.). |
-| `tags`        | string[]                 | Tags applied to this world record. |
-| `imageUrl`    | string \| null           | Thumbnail image URL from VRChat API. |
-| `vrchatUrl`   | string                   | Link to the world on the VRChat website. |
-| `quality`     | `"good"` \| `"bad"` \| null | Manual quality rating (if set). |
-| `createdAt`   | string \| undefined      | ISO 8601 timestamp of when the record was created. |
+| Field             | Type                     | Description |
+|-------------------|--------------------------|-------------|
+| `worldId`         | string                   | VRChat world ID (e.g. `wrld_abc123`). |
+| `name`            | string \| null           | Display name of the world. |
+| `authorName`      | string \| null           | Name of the author / creator. |
+| `capacity`        | number \| null           | Maximum player capacity. |
+| `platforms`       | string[]                 | Supported platforms (`android`, `standalonewindows`, etc.). |
+| `tags`            | string[]                 | Tags applied to this world record. |
+| `imageUrl`        | string \| null           | Thumbnail image URL from VRChat API. |
+| `vrchatUrl`       | string                   | Link to the world on the VRChat website. |
+| `quality`         | `"good"` \| `"bad"` \| null | Manual quality rating (if set). |
+| `createdAt`       | string \| undefined      | ISO 8601 timestamp of when the record was created. |
+| `internalAddDate` | string \| null           | ISO 8601 timestamp of when the world was originally tagged, if known. |
 
 Internal fields such as `guildId`, `messageId`, `sourceContent`, and `vrchatData` are intentionally stripped from API responses.
 
@@ -410,6 +428,10 @@ curl -H "Authorization: Bearer my-token" \
 # List worlds with capacity between 10 and 40, marked as good
 curl -H "Authorization: Bearer my-token" \
   "http://localhost:3000/api/worlds?minCapacity=10&maxCapacity=40&quality=good"
+
+# List worlds tagged in the last 7 days
+curl -H "Authorization: Bearer my-token" \
+  "http://localhost:3000/api/worlds?dayRange=7"
 
 # Get a specific world
 curl -H "Authorization: Bearer my-token" \

--- a/src/apiServer/apiServer.test.ts
+++ b/src/apiServer/apiServer.test.ts
@@ -635,6 +635,108 @@ describe('API Server', () => {
         error: 'minCapacity must be an integer'
       });
     });
+
+    it('passes dayRange filter to repository', async () => {
+      const getAllPaginated = jest.fn(() => ({ total: 0, rows: [] }));
+      asMock(getWorldRepository).mockReturnValue(
+        createMockRepo({ getAllPaginated })
+      );
+
+      await app.inject({
+        method: 'GET',
+        url: '/api/worlds?dayRange=7',
+        headers: { authorization: 'Bearer test-token' }
+      });
+
+      expect(getAllPaginated).toHaveBeenCalledWith(
+        50,
+        0,
+        expect.objectContaining({ dayRange: 7 })
+      );
+    });
+
+    it('clamps dayRange above 365 to 365', async () => {
+      const getAllPaginated = jest.fn(() => ({ total: 0, rows: [] }));
+      asMock(getWorldRepository).mockReturnValue(
+        createMockRepo({ getAllPaginated })
+      );
+
+      await app.inject({
+        method: 'GET',
+        url: '/api/worlds?dayRange=999',
+        headers: { authorization: 'Bearer test-token' }
+      });
+
+      expect(getAllPaginated).toHaveBeenCalledWith(
+        50,
+        0,
+        expect.objectContaining({ dayRange: 365 })
+      );
+    });
+
+    it('treats negative dayRange as no filter', async () => {
+      const getAllPaginated = jest.fn(() => ({ total: 0, rows: [] }));
+      asMock(getWorldRepository).mockReturnValue(
+        createMockRepo({ getAllPaginated })
+      );
+
+      await app.inject({
+        method: 'GET',
+        url: '/api/worlds?dayRange=-5',
+        headers: { authorization: 'Bearer test-token' }
+      });
+
+      expect(getAllPaginated).toHaveBeenCalledWith(50, 0, undefined);
+    });
+
+    it('treats zero dayRange as no filter', async () => {
+      const getAllPaginated = jest.fn(() => ({ total: 0, rows: [] }));
+      asMock(getWorldRepository).mockReturnValue(
+        createMockRepo({ getAllPaginated })
+      );
+
+      await app.inject({
+        method: 'GET',
+        url: '/api/worlds?dayRange=0',
+        headers: { authorization: 'Bearer test-token' }
+      });
+
+      expect(getAllPaginated).toHaveBeenCalledWith(50, 0, undefined);
+    });
+
+    it('treats non-numeric dayRange as no filter', async () => {
+      const getAllPaginated = jest.fn(() => ({ total: 0, rows: [] }));
+      asMock(getWorldRepository).mockReturnValue(
+        createMockRepo({ getAllPaginated })
+      );
+
+      await app.inject({
+        method: 'GET',
+        url: '/api/worlds?dayRange=abc',
+        headers: { authorization: 'Bearer test-token' }
+      });
+
+      expect(getAllPaginated).toHaveBeenCalledWith(50, 0, undefined);
+    });
+
+    it('combines dayRange filter with tag filter', async () => {
+      const getAllPaginated = jest.fn(() => ({ total: 0, rows: [] }));
+      asMock(getWorldRepository).mockReturnValue(
+        createMockRepo({ getAllPaginated })
+      );
+
+      await app.inject({
+        method: 'GET',
+        url: '/api/worlds?dayRange=7&tag=horror',
+        headers: { authorization: 'Bearer test-token' }
+      });
+
+      expect(getAllPaginated).toHaveBeenCalledWith(
+        50,
+        0,
+        expect.objectContaining({ dayRange: 7, tags: ['horror'] })
+      );
+    });
   });
 
   describe('GET /api/worlds/:worldId', () => {

--- a/src/apiServer/routes/worlds.ts
+++ b/src/apiServer/routes/worlds.ts
@@ -36,6 +36,11 @@ const worldsRoute: FastifyPluginAsync = async (fastify: FastifyInstance) => {
     const limit = Math.min(Number(query.limit ?? 50), 500);
     const offset = Number(query.offset ?? 0);
 
+    const dayRange =
+      typeof query.dayRange === 'string'
+        ? Math.max(0, Math.min(parseInt(query.dayRange, 10) || 0, 365))
+        : 0;
+
     const tags = parseStringListQuery(query.tag);
     const platforms = parseStringListQuery(query.platform);
     const worldIds = parseStringListQuery(query.worldId);
@@ -86,6 +91,7 @@ const worldsRoute: FastifyPluginAsync = async (fastify: FastifyInstance) => {
       minCapacity?: number;
       maxCapacity?: number;
       worldIds?: string[];
+      dayRange?: number;
     } = {};
     if (tags) filters.tags = tags;
     if (platforms) filters.platforms = platforms;
@@ -93,6 +99,7 @@ const worldsRoute: FastifyPluginAsync = async (fastify: FastifyInstance) => {
     if (quality) filters.quality = quality;
     if (minCapacity !== undefined) filters.minCapacity = minCapacity;
     if (maxCapacity !== undefined) filters.maxCapacity = maxCapacity;
+    if (dayRange > 0) filters.dayRange = dayRange;
 
     const search =
       typeof query.search === 'string' ? query.search.trim() : undefined;

--- a/src/utils/database/worldRepository.test.ts
+++ b/src/utils/database/worldRepository.test.ts
@@ -796,6 +796,113 @@ describe('WorldRepository', () => {
     });
   });
 
+  describe('dayRange filtering', () => {
+    beforeEach(() => {
+      db.prepare('DELETE FROM world_records').run();
+
+      const nowSeconds = Math.floor(Date.now() / 1000);
+
+      repo.upsert(
+        createTestRecord({
+          worldId: 'wrld_today',
+          guildId: 'guild-1',
+          internalAddDate: nowSeconds - 60 * 60 // 1 hour ago
+        })
+      );
+      repo.upsert(
+        createTestRecord({
+          worldId: 'wrld_recent',
+          guildId: 'guild-1',
+          internalAddDate: nowSeconds - 60 * 60 * 24 * 3 // 3 days ago
+        })
+      );
+      repo.upsert(
+        createTestRecord({
+          worldId: 'wrld_old',
+          guildId: 'guild-1',
+          internalAddDate: nowSeconds - 60 * 60 * 24 * 30 // 30 days ago
+        })
+      );
+      repo.upsert(
+        createTestRecord({
+          worldId: 'wrld_null_internal_add_date',
+          guildId: 'guild-1',
+          internalAddDate: null,
+          createdAt: nowSeconds - 60 * 60 * 24 * 2 // 2 days ago
+        })
+      );
+      // Force the null value because upsert backfills internal_add_date when null.
+      db.prepare(
+        'UPDATE world_records SET internal_add_date = NULL WHERE world_id = ? AND guild_id = ?'
+      ).run('wrld_null_internal_add_date', 'guild-1');
+    });
+
+    it('returns only worlds within the last N days', () => {
+      const { rows } = repo.getAllPaginated(10, 0, { dayRange: 7 });
+      const worldIds = rows.map((r) => r.worldId).sort();
+      expect(worldIds).toContain('wrld_today');
+      expect(worldIds).toContain('wrld_recent');
+      expect(worldIds).toContain('wrld_null_internal_add_date');
+      expect(worldIds).not.toContain('wrld_old');
+    });
+
+    it('returns only records within the last 24 hours when dayRange is 1', () => {
+      const { rows, total } = repo.getAllPaginated(10, 0, { dayRange: 1 });
+      expect(total).toBe(1);
+      expect(rows.map((r) => r.worldId)).toContain('wrld_today');
+    });
+
+    it('falls back to created_at when internal_add_date is null', () => {
+      const { rows } = repo.getAllPaginated(10, 0, { dayRange: 7 });
+      expect(
+        rows.some((r) => r.worldId === 'wrld_null_internal_add_date')
+      ).toBe(true);
+    });
+
+    it('does not apply a date filter when dayRange is 0', () => {
+      const { rows, total } = repo.getAllPaginated(10, 0, { dayRange: 0 });
+      expect(total).toBe(4);
+      expect(rows).toHaveLength(4);
+    });
+
+    it('combines dayRange with other filters', () => {
+      repo.upsert(
+        createTestRecord({
+          worldId: 'wrld_recent_match',
+          guildId: 'guild-1',
+          tags: ['horror'],
+          internalAddDate: Math.floor(Date.now() / 1000) - 60 * 60 * 24 * 2
+        })
+      );
+      repo.upsert(
+        createTestRecord({
+          worldId: 'wrld_recent_no_match',
+          guildId: 'guild-1',
+          tags: ['game'],
+          internalAddDate: Math.floor(Date.now() / 1000) - 60 * 60 * 24 * 2
+        })
+      );
+      repo.upsert(
+        createTestRecord({
+          worldId: 'wrld_old_match',
+          guildId: 'guild-1',
+          tags: ['horror'],
+          internalAddDate: Math.floor(Date.now() / 1000) - 60 * 60 * 24 * 30
+        })
+      );
+
+      const { rows } = repo.getAllPaginated(10, 0, {
+        dayRange: 7,
+        tags: ['horror']
+      });
+      const worldIds = rows.map((r) => r.worldId).sort();
+      expect(worldIds).toContain('wrld_recent_match');
+      expect(worldIds).toContain('wrld_today');
+      expect(worldIds).not.toContain('wrld_old_match');
+      expect(worldIds).not.toContain('wrld_recent_no_match');
+    });
+  });
+
   describe('platform filtering', () => {
     beforeEach(() => {
       db.prepare('DELETE FROM world_records').run();

--- a/src/utils/database/worldRepository.ts
+++ b/src/utils/database/worldRepository.ts
@@ -304,6 +304,7 @@ export class WorldRepository {
     minCapacity?: number;
     maxCapacity?: number;
     worldIds?: string[];
+    dayRange?: number;
   }): { whereClause: string; params: (string | number)[] } {
     const whereParts: string[] = [];
     const params: (string | number)[] = [];
@@ -371,6 +372,12 @@ export class WorldRepository {
       params.push(filters.maxCapacity);
     }
 
+    if (filters?.dayRange !== undefined && filters.dayRange > 0) {
+      whereParts.push(
+        `COALESCE(internal_add_date, created_at) >= CAST(strftime('%s', 'now', '-${filters.dayRange} days') AS INTEGER)`
+      );
+    }
+
     const whereClause =
       whereParts.length > 0 ? `WHERE ${whereParts.join(' AND ')}` : '';
 
@@ -395,6 +402,7 @@ export class WorldRepository {
       minCapacity?: number;
       maxCapacity?: number;
       worldIds?: string[];
+      dayRange?: number;
     }
   ): { rows: WorldRecord[]; total: number } {
     const { whereClause, params } = this.buildWhereClause(filters);


### PR DESCRIPTION
Closes #118

## Summary
Adds the `dayRange` query parameter to `GET /api/worlds` so the dashboard can filter worlds tagged within the last N days.

## Changes
- `src/apiServer/routes/worlds.ts`: parses `dayRange`, clamps it to `0–365`, and passes it to the repository when n 0. Negative values are treated as `0` (no filter).
- `src/utils/database/worldRepository.ts`: adds `dayRange` filtering via `COALESCE(internal_add_date, created_at)` against the UTC SQLite boundary. The `strftime(...)` result is cast to `INTEGER` to avoid a SQLite type-comparison quirk with `COALESCE`.
- Tests added in `src/apiServer/apiServer.test.ts` and `src/utils/database/worldRepository.test.ts`.
- Documentation updated in `docs/API.md` and `README.md`.

## Validation
- Full test suite passes: `283 passed, 283 total`.
- Lint passes.
