### PR TITLE
chore: ignore db_original.json in git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -123,5 +123,6 @@ db.back.json
 # dev related
 db.json
 db.json.back
+db_original.json
 worlds.db*
 


### PR DESCRIPTION
Prevents the accidentally-pushed db_original.json from being re-added to the repo after its history was rewritten out of main.