### PR TITLE
[FEAT]: Add 'liminal' to canonical world tag taxonomy

### DIFF
--- a/scripts/randomize-worlds-tags-and-quality.standalone.js
+++ b/scripts/randomize-worlds-tags-and-quality.standalone.js
@@ -34,7 +34,8 @@ const ALL_TAGS = [
   'tech',
   'nature',
   'gamerip',
-  'portal'
+  'portal',
+  'liminal'
 ];
 
 const FAVORED_TAGS = new Set(['kino', 'chill', 'gamerip']);

--- a/scripts/randomize-worlds-tags-and-quality.ts
+++ b/scripts/randomize-worlds-tags-and-quality.ts
@@ -20,7 +20,8 @@ const ALL_TAGS = [
   'tech',
   'nature',
   'gamerip',
-  'portal'
+  'portal',
+  'liminal'
 ];
 
 const FAVORED_TAGS = new Set(['kino', 'chill', 'gamerip']);

--- a/src/utils/tagExtractor/index.ts
+++ b/src/utils/tagExtractor/index.ts
@@ -18,7 +18,8 @@ const TAXONOMY = new Set<string>([
   'tech',
   'nature',
   'gamerip',
-  'portal'
+  'portal',
+  'liminal'
 ]);
 
 /**

--- a/src/utils/tagExtractor/tagExtractor.test.ts
+++ b/src/utils/tagExtractor/tagExtractor.test.ts
@@ -66,6 +66,17 @@ describe('tagExtractor', () => {
         'chill'
       ]);
     });
+
+    it('extracts liminal from "Tags:" lines', () => {
+      expect(extractTags('Tags: liminal')).toEqual(['liminal']);
+    });
+
+    it('extracts liminal alongside other tags', () => {
+      expect(extractTags('Tags: horror, liminal')).toEqual([
+        'horror',
+        'liminal'
+      ]);
+    });
   });
 
   describe('canonicalization', () => {


### PR DESCRIPTION
Closes #122

## Changes
- Add `liminal` to the `TAXONOMY` set in `src/utils/tagExtractor/index.ts`
- Mirror in `scripts/randomize-worlds-tags-and-quality.standalone.js`
- Add test cases for `Tags: liminal` and `Tags: horror, liminal`

## Verification
- `pnpm test`: 285 tests pass (17 suites)
- `pnpm lint`: clean