### PR TITLE
ci: add release PR workflow (main -> release)

### DIFF
--- a/.github/workflows/release-pr-release.yml
+++ b/.github/workflows/release-pr-release.yml
@@ -1,0 +1,81 @@
+name: Create release PR (main -> release)
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  create-release-pr:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout main
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: main
+
+      - name: Fetch release
+        run: git fetch origin release
+
+      - name: Check for incoming commits
+        id: incoming
+        run: |
+          if [ -z "$(git log origin/release..origin/main)" ]; then
+            echo "Nothing to release — origin/release is up to date with origin/main."
+            echo "no_changes=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "no_changes=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Abort when nothing to release
+        if: steps.incoming.outputs.no_changes == 'true'
+        run: exit 1
+
+      - name: Build PR body
+        id: body
+        run: |
+          {
+            echo "## Summary"
+            echo ""
+            echo "Merge latest changes from \`main\` into \`release\` for the upcoming release."
+            echo ""
+            echo "## Incoming commits"
+            echo ""
+            git log --reverse --pretty=format:"- \`%h\` %s" origin/release..origin/main
+            echo ""
+            echo ""
+            echo "## Verification checklist"
+            echo ""
+            echo "- [ ] \`pnpm test\` passes."
+            echo "- [ ] \`pnpm lint\` is clean."
+            echo "- [ ] Release branch diff reviewed for unexpected changes."
+            echo "- [ ] No new console errors or broken network requests introduced."
+          } > /tmp/release-pr-body.md
+          echo "Created body with $(git log --oneline origin/release..origin/main | wc -l | tr -d ' ') incoming commit(s)"
+
+      - name: Find existing release PR
+        id: find
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          PR_NUMBER=$(gh pr list --base release --head main --state open \
+            --search 'in:title "Release: Merge main into release"' --json number --jq '.[0].number')
+          echo "pr_number=${PR_NUMBER:-}" >> "$GITHUB_OUTPUT"
+
+      - name: Create release PR
+        if: steps.find.outputs.pr_number == ''
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh pr create --base release --head main \
+            --title "Release: Merge main into release" \
+            --body-file /tmp/release-pr-body.md
+
+      - name: Update existing release PR
+        if: steps.find.outputs.pr_number != ''
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh pr edit "${{ steps.find.outputs.pr_number }}" --body-file /tmp/release-pr-body.md


### PR DESCRIPTION
Adds a manually-dispatched workflow that opens (or updates) a release PR merging `main` into `release`, mirroring the `release-pr-production.yml` workflow from vrc-world-dashboard-api but adapted to this repo's `release` branch.

- Aborts with a clear message when there are no incoming commits
- Builds a PR body with a summary, commit list, and verification checklist
- Creates a new PR or updates the existing open one